### PR TITLE
Release v0.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Next
+## 0.15.3 (2017-11-09)
 
 **Rename to `turbo-gulp`**. This package was previously named `demurgos-web-build-tools`.
 This version is fully compatible: you can just change the name of your dependency.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-gulp",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-gulp",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Gulp tasks generator to boost your web projects.",
   "private": false,
   "main": "dist/lib/index",

--- a/tools/continuous-deployment.travis.sh
+++ b/tools/continuous-deployment.travis.sh
@@ -64,7 +64,7 @@ NPM_NEXT_TIME=`[ -z "${NPM_NEXT_DATE}" ] && echo "0" || date -d ${NPM_NEXT_DATE}
 # Hash of the git head for the pre-release build on npm
 NPM_NEXT_GIT_HEAD=`npm view "${NPM_LOCAL_NAME}@next" gitHead 2> /dev/null || echo ""`
 # Version of the latest release
-NPM_LATEST_VERSION=`npm view "${NPM_LOCAL_NAME}@next" version 2> /dev/null || echo ""`
+NPM_LATEST_VERSION=`npm view "${NPM_LOCAL_NAME}@latest" version 2> /dev/null || echo ""`
 # Local version of the package
 NPM_LOCAL_VERSION=`jq --raw-output .version < package.json`
 


### PR DESCRIPTION
**Rename to `turbo-gulp`**. This package was previously named
`demurgos-web-build-tools`. This version is fully compatible: you can
just change the name of your dependency.

See demurgos/turbo-gulp#42