### PR TITLE
Add support for custom copy for distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## Next
 
+- **[Fix]** Add support for custom additional copy for distribution builds. [#49][issue-49]
 - **[Internal]** Update self-dependency to `turbo-gulp`
 - **[Internal]** Add link to license in `README.md`
+
+[issue-49]: https://github.com/demurgos/turbo-gulp/issues/49
 
 ## 0.15.3 (2017-11-09)
 

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -52,7 +52,6 @@ const lib: buildTools.LibTarget = {
   },
   copy: [
     {
-      name: "json",
       files: ["**/*.json"],
     },
   ],
@@ -72,7 +71,6 @@ const test: buildTools.MochaTarget = {
   },
   copy: [
     {
-      name: "e2e",
       src: "e2e",
       // <project-name>/(project|test-resources)/<any>
       files: ["*/project/**/*", "*/test-resources/**/*"],

--- a/src/lib/options/copy.ts
+++ b/src/lib/options/copy.ts
@@ -18,12 +18,4 @@ export interface CopyOptions {
    * Default: target output directory
    */
   dest?: string;
-
-  /**
-   * Name of the copy operation.
-   * It will be used for the name of the task: `<targetName>:build:copy:<copyName>`.
-   * If you do not define it, it will be "anonymous" and will only
-   * be called by `<targetName>:build:copy`
-   */
-  name?: string;
 }


### PR DESCRIPTION
This commit adds support for `dist.copy` for lib targets. This
property allows to perform additional copy operation when creating
the dist build. The default value is to copy the Markdown files
from the root.

Closes demurgos/turbo-gulp#49