### PR TITLE
Release v0.15.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
-## Next
+## 0.15.4 (2017-11-10)
 
-- **[Fix]** Add support for custom additional copy for distribution builds. [#49][issue-49]
+- **[Fix]** Add support for custom additional copy for distribution builds. [#49](https://github.com/demurgos/turbo-gulp/issues/49)
 - **[Internal]** Update self-dependency to `turbo-gulp`
 - **[Internal]** Add link to license in `README.md`
-
-[issue-49]: https://github.com/demurgos/turbo-gulp/issues/49
 
 ## 0.15.3 (2017-11-09)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-gulp",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-gulp",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "Gulp tasks generator to boost your web projects.",
   "private": false,
   "main": "dist/lib/index",


### PR DESCRIPTION
- **[Fix]** Add support for custom additional copy for distribution
  builds. #49
- **[Internal]** Update self-dependency to `turbo-gulp`
- **[Internal]** Add link to license in `README.md`