### PR TITLE
Fix path to source in source maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- **[Fix]** Fix path to source in source maps.
+
 ## 0.15.5 (2017-11-10)
 
 - **[Feature]** Enable the following TsLint rules: `no-duplicate-switch-case`, `no-implicit-dependencies`,

--- a/src/test/utils/matcher.spec.ts
+++ b/src/test/utils/matcher.spec.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 import { Minimatch } from "minimatch";
-import * as matcher from "./matcher";
+import * as matcher from "../../lib/utils/matcher";
 
 describe("matcher.asString", function () {
   const data: string[] = [


### PR DESCRIPTION
This commit ensures that the relative path to the sources is
properly set, even if the source and build directories are distinct.