### PR TITLE
Disable `number-literal-format` in default Tslint rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 - **[Fix]** Fix path to source in source maps.
+- **[Fix]** Disable `number-literal-format` in default Tslint rules. It enforced uppercase for hex.
 
 ## 0.15.5 (2017-11-10)
 

--- a/src/lib/options/tslint.ts
+++ b/src/lib/options/tslint.ts
@@ -215,7 +215,8 @@ export const DEFAULT_UNTYPED_TSLINT_RULES: TslintConfiguration.RawRulesConfig = 
   // Disallows the use of require statements except in import statements.
   "no-var-requires": true,
   // Checks that decimal literals should begin with `0.` instead of just `.`, and should not end with a trailing `0`.
-  "number-literal-format": true,
+  // TODO: Enable it when the option to enforce lowercase hex is available
+  "number-literal-format": false,
   // Enforces consistent object literal property quote style.
   "object-literal-key-quotes": [true, "consistent-as-needed"],
   // Enforces use of ES6 object literal shorthand when possible.


### PR DESCRIPTION
This rule is disabled because it enforces uppercase hex without
any option to configure this behavior.