### PR TITLE
Release v0.15.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Next
+## 0.15.6 (2017-11-29)
 
 - **[Fix]** Fix path to source in source maps.
 - **[Fix]** Disable `number-literal-format` in default Tslint rules. It enforced uppercase for hex.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Gulp tasks to boost high-quality projects.
 [![npm](https://img.shields.io/npm/v/turbo-gulp.svg?maxAge=2592000)](https://www.npmjs.com/package/turbo-gulp)
 [![GitHub repository](https://img.shields.io/badge/Github-demurgos%2Fturbo--gulp-blue.svg)](https://github.com/demurgos/turbo-gulp)
 [![Build status](https://img.shields.io/travis/demurgos/turbo-gulp/master.svg?maxAge=2592000)](https://travis-ci.org/demurgos/turbo-gulp)
+[![Codecov](https://codecov.io/gh/demurgos/turbo-gulp/branch/master/graph/badge.svg)](https://codecov.io/gh/demurgos/turbo-gulp)
 [![Greenkeeper badge](https://badges.greenkeeper.io/demurgos/turbo-gulp.svg)](https://greenkeeper.io/)
 
 This package was known as `demurgos-web-build-tools` before `v0.15.2` (2017-11-09).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-gulp",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-gulp",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "description": "Gulp tasks to boost high-quality projects.",
   "author": "Charles Samborski <demurgos@demurgos.net> (https://demurgos.net)",
   "license": "MIT",


### PR DESCRIPTION
- **[Fix]** Fix path to source in source maps.
- **[Fix]** Disable `number-literal-format` in default Tslint rules.
- **[Internal]** Enable integration with Greenkeeper.
- **[Internal]** Enable integration with Codecov
- **[Internal]** Enable code coverage