### PR TITLE
Release v0.15.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## Next
+## 0.15.7 (2017-11-29)
 
-- **[Feature]** Add `coverage` task to `mocha` target, use it by default with the `start` task
+- **[Feature]** Add `coverage` task to `mocha` target, use it for the default task
 
 ## 0.15.6 (2017-11-29)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-gulp",
-  "version": "0.15.6",
+  "version": "0.15.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-gulp",
-  "version": "0.15.6",
+  "version": "0.15.7",
   "description": "Gulp tasks to boost high-quality projects.",
   "author": "Charles Samborski <demurgos@demurgos.net> (https://demurgos.net)",
   "license": "MIT",


### PR DESCRIPTION
- **[Feature]** Add `coverage` task to `mocha` target, use it for the default task