### PR TITLE
Release v0.15.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Next
+## 0.15.8 (2017-12-05)
 
 - **[Fix]** Exit with non-zero code if command tested with coverage fails
 - **[Fix]** Solve duplicated error message when using the `run` mocha task.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-gulp",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-gulp",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "description": "Gulp tasks to boost high-quality projects.",
   "author": "Charles Samborski <demurgos@demurgos.net> (https://demurgos.net)",
   "license": "MIT",


### PR DESCRIPTION
- **[Fix]** Exit with non-zero code if command tested with coverage
  fails
- **[Fix]** Solve duplicated error message when using the `run` mocha
  task.
- **[Fix]** Exit with non-zero code when building scripts fails.