### PR TITLE
Release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Next
+## 0.16.0 (2017-01-09)
 
 - **[Breaking change]** Enable `allowSyntheticDefaultImports` and `esModuleInterop` by default
 - **[Fix]** Allow deep module imports in default Tslint rules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-gulp",
-  "version": "0.15.8",
+  "version": "0.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-gulp",
-  "version": "0.15.8",
+  "version": "0.16.0",
   "description": "Gulp tasks to boost high-quality projects.",
   "author": "Charles Samborski <demurgos@demurgos.net> (https://demurgos.net)",
   "license": "MIT",

--- a/tools/continuous-deployment.travis.sh
+++ b/tools/continuous-deployment.travis.sh
@@ -144,6 +144,9 @@ echo "Successfully deployed to npm"
 # gh-pages deployment                                                         #
 ###############################################################################
 
+echo "Skipping deployment to gh-pages: waiting for typedoc@0.10.0"
+exit 0
+
 echo "Deploying to gh-pages..."
 
 # Get the deploy key by using Travis's stored variables to decrypt deploy_key.enc


### PR DESCRIPTION
- **[Breaking change]** Enable `allowSyntheticDefaultImports` and `esModuleInterop` by default
- **[Fix]** Allow deep module imports in default Tslint rules
- **[Fix]** Drop dependency on deprecated `gulp-util`
- **[Internal]** Replace most custom typings by types from `@types`