### PR TITLE
Release v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Next (2017-01-20)
+## 0.16.1 (2017-01-20)
 
 - **[Feature]** Support `mocha` tests on `.mjs` files (using `@std/esm`). Enabled by default
   if `outModules` is configured to emit `.mjs`. **You currently need to add

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-gulp",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-gulp",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Gulp tasks to boost high-quality projects.",
   "author": "Charles Samborski <demurgos@demurgos.net> (https://demurgos.net)",
   "license": "MIT",


### PR DESCRIPTION
- **[Feature]** Support `mocha` tests on `.mjs` files (using `@std/esm`). Enabled by default if `outModules` is configured to emit `.mjs`. **You currently need to add `"@std/esm": {"esm": "cjs"}` to your `package.json`.**