### PR TITLE
Fix continuous deployment script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ before_script:
 
 script:
 - npm test
-- echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 - ./tools/continuous-deployment.travis.sh
 - node node_modules/.bin/nyc report --reporter=text-lcov > coverage.lcov
 - node node_modules/.bin/codecov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next
 
 - **[Breaking change]** Drop support for Pug, Sass, Angular & Webpack
+- **[Internal]** Fix continuous deployment script (stop confusing PRs to master
+  with push to master)
 
 ## 0.17.1 (2017-05-03)
 

--- a/tools/continuous-deployment.travis.sh
+++ b/tools/continuous-deployment.travis.sh
@@ -20,106 +20,134 @@
 # Exit with nonzero exit code if anything fails
 set -e
 
-###############################################################################
-# Configuration                                                               #
-###############################################################################
+################################################################################
+# Configuration                                                                #
+################################################################################
 
 # Space out deploys by at least this interval, 1day == 86400sec
 DEPLOY_INTERVAL=86400
+# Deploy only for CI on this repo
+MAIN_REPO="demurgos/turbo-gulp"
 # Deploy only on merge commit to this branch
-DEPLOYMENT_BRANCH="master"
+MAIN_BRANCH="master"
+# Path to `package.json`, used to retrieve version and package name
+PACKAGE_JSON="./package.json"
 # Id in the name of the key and iv files
 TRAVIS_ENCRYPTION_ID="fa98f77d113d"
-# Build id used for the publication of pre-release builds to `npm`
-BUILD_ID=${TRAVIS_BUILD_NUMBER}
-# Branch name or tag name
-GIT_HEAD_BRANCH=${TRAVIS_BRANCH}
-# If this is build for a tag, name of the tag (empty string otherwise)
-GIT_HEAD_TAG=${TRAVIS_TAG}
-# Possible values: "branch", "tag", "pr"
-CI_BUILD_TYPE=`[[ ${TRAVIS_PULL_REQUEST} == "true" ]] && echo "pr" || [ -n "${TRAVIS_TAG}" ] && echo "tag" || echo "branch"`
 
-###############################################################################
-# Get information about the current build                                     #
-###############################################################################
+################################################################################
+# Platform-dependent build info (Travis CI)                                    #
+################################################################################
+
+# Build id used for the publication of pre-release builds to `npm`
+# (TRAVIS_BUILD_NUMBER: Unique id of this build)
+BUILD_ID="${TRAVIS_BUILD_NUMBER}"
+# Branch name or tag name
+# (TRAVIS_BRANCH: `tag` build => tag name; `branch` build => branch name, `pr` => target branch name)
+GIT_HEAD_BRANCH="${TRAVIS_BRANCH}"
+# If this is build for a tag, name of the tag (empty string otherwise)
+GIT_HEAD_TAG="${TRAVIS_TAG}"
+# Possible values: "branch", "tag", "pr"
+# (TRAVIS_PULL_REQUEST: `false` if it is not a PR, otherwise PR id)
+# (TRAVIS_TAG: Tag name if it's a tag build, otherwise empty string)
+if [[ "${TRAVIS_PULL_REQUEST}" != "false" ]]; then
+  CI_BUILD_TYPE="pr"
+elif [ -n "${TRAVIS_TAG}" ]; then
+  CI_BUILD_TYPE="tag"
+else
+  CI_BUILD_TYPE="branch"
+fi
+
+################################################################################
+# Platform-independent build info                                              #
+################################################################################
 
 # If the current build is a tag build, check if the corresponding tag is on the deployment branch
-IS_GIT_HEAD_TAG_ON_DEPLOYMENT_BRANCH="false"
+IS_GIT_HEAD_TAG_ON_MAIN_BRANCH="false"
 if [[ "${CI_BUILD_TYPE}" == "tag" ]]; then
   # Revert `--single-branch` (caused by `--depth`)
   git config remote.origin.fetch refs/heads/*:refs/remotes/origin/*
   # Fetch all (TODO: Only fetch the last commits of the deployment branch)
   git fetch --quiet --unshallow --tags
-  # List the tags on the deployment branch (ignore errors), use grep to perform an exact match and test if the match returns the tag
-  IS_GIT_HEAD_TAG_ON_DEPLOYMENT_BRANCH=`! (git tag --merged "origin/${DEPLOYMENT_BRANCH}" 2> /dev/null || true) | grep --quiet --fixed-strings --line-regexp "${GIT_HEAD_TAG}" && echo "false" || echo "true"`
+  # List the tags on the main branch (ignore errors), use grep to perform an exact match and test if the match returns the tag
+  IS_GIT_HEAD_TAG_ON_MAIN_BRANCH=$(! (git tag --merged "origin/${MAIN_BRANCH}" 2> /dev/null || true) | grep --quiet --fixed-strings --line-regexp "${GIT_HEAD_TAG}" && echo "false" || echo "true")
 fi
 # Time of the latest commit in seconds since UNIX epoch
-GIT_HEAD_TIME=`git log -1 --pretty=format:%ct`
+GIT_HEAD_TIME=$(git log -1 --pretty=format:%ct)
 # Package name on npm
-NPM_LOCAL_NAME=`jq --raw-output .name < package.json`
+NPM_LOCAL_NAME=$(jq --raw-output .name < "${PACKAGE_JSON}")
 # ISO date or empty string: time of last modification of the pre-release build on npm
-NPM_NEXT_DATE=`npm view "${NPM_LOCAL_NAME}@next" time.modified 2> /dev/null || echo ""`
+NPM_NEXT_DATE=$(npm view "${NPM_LOCAL_NAME}@next" time.modified 2> /dev/null || echo "")
 # Parse the ISO date to a timestamp if we got a non-empty result (default is 0 - UNIX epoch)
-NPM_NEXT_TIME=`[ -z "${NPM_NEXT_DATE}" ] && echo "0" || date -d ${NPM_NEXT_DATE} "+%s"`
+NPM_NEXT_TIME=$([ -z "${NPM_NEXT_DATE}" ] && echo "0" || date -d ${NPM_NEXT_DATE} "+%s")
 # Hash of the git head for the pre-release build on npm
-NPM_NEXT_GIT_HEAD=`npm view "${NPM_LOCAL_NAME}@next" gitHead 2> /dev/null || echo ""`
+NPM_NEXT_GIT_HEAD=$(npm view "${NPM_LOCAL_NAME}@next" gitHead 2> /dev/null || echo "")
 # Version of the latest release
-NPM_LATEST_VERSION=`npm view "${NPM_LOCAL_NAME}@latest" version 2> /dev/null || echo ""`
+NPM_LATEST_VERSION=$(npm view "${NPM_LOCAL_NAME}@latest" version 2> /dev/null || echo "")
 # Local version of the package
-NPM_LOCAL_VERSION=`jq --raw-output .version < package.json`
+NPM_LOCAL_VERSION=$(jq --raw-output .version < "${PACKAGE_JSON}")
 
-echo "ci: build id: $BUILD_ID"
-echo "ci: build type: $CI_BUILD_TYPE"
-echo "git: branch: $GIT_HEAD_BRANCH"
-echo "git: tag: $GIT_HEAD_TAG"
-echo "git: is tag on deployment branch ($DEPLOYMENT_BRANCH): $IS_GIT_HEAD_TAG_ON_DEPLOYMENT_BRANCH"
-echo "npm: @next modification date: $NPM_NEXT_DATE"
-echo "npm: @latest version: $NPM_LATEST_VERSION"
-echo "npm: local version: $NPM_LOCAL_VERSION"
+echo "ci: build id: ${BUILD_ID}"
+echo "ci: build type: ${CI_BUILD_TYPE}"
+case "${CI_BUILD_TYPE}" in
+  "pr")
+    echo "git: target branch: ${GIT_HEAD_BRANCH}"
+    ;;
+  "tag")
+    echo "git: tag: ${GIT_HEAD_TAG}"
+    echo "git: is tag on deployment branch (${MAIN_BRANCH}): ${IS_GIT_HEAD_TAG_ON_MAIN_BRANCH}"
+    ;;
+  "branch")
+    echo "git: branch: ${GIT_HEAD_BRANCH}"
+    ;;
+esac
+echo "npm: @next modification date: ${NPM_NEXT_DATE}"
+echo "npm: @latest version: ${NPM_LATEST_VERSION}"
+echo "npm: local version: ${NPM_LOCAL_VERSION}"
 echo ""
 
-###############################################################################
-# Check if we should deploy                                                   #
-###############################################################################
+################################################################################
+# Check if we should deploy                                                    #
+################################################################################
 
 
-case ${CI_BUILD_TYPE} in
+case "${CI_BUILD_TYPE}" in
   "pr")
     echo "Skipping deployment: This is only a Pull Request."
     exit 0
     ;;
   "tag")
     # Only commits to the source branch should deploy
-    if [ "$IS_GIT_HEAD_TAG_ON_DEPLOYMENT_BRANCH" != "true" ]; then
-      echo "Skipping deployment: Current tag $GIT_HEAD_TAG is not on the deployment branch $DEPLOYMENT_BRANCH."
+    if [ "${IS_GIT_HEAD_TAG_ON_MAIN_BRANCH}" != "true" ]; then
+      echo "Skipping deployment: Current tag ${GIT_HEAD_TAG} is not on the main branch ${MAIN_BRANCH}."
       exit 0
     fi
     # Release if there is a git tag matching the version in `package.json` (pre-release by default).
-    if [[ ${GIT_HEAD_TAG} != "v$NPM_LOCAL_VERSION" ]]; then
-      echo "Skipping deployment: Tag ${GIT_HEAD_TAG} is not v$NPM_LOCAL_VERSION."
+    if [[ "${GIT_HEAD_TAG}" != "v${NPM_LOCAL_VERSION}" ]]; then
+      echo "Skipping deployment: Tag ${GIT_HEAD_TAG} is not v${NPM_LOCAL_VERSION}."
       exit 0
     fi
     ;;
   "branch")
     # Only commits to the source branch should deploy
-    if [ "$GIT_HEAD_BRANCH" != "$DEPLOYMENT_BRANCH" ]; then
-        echo "Skipping deployment: Not on the deployment branch $DEPLOYMENT_BRANCH."
+    if [ "${GIT_HEAD_BRANCH}" != "${MAIN_BRANCH}" ]; then
+        echo "Skipping deployment: Not on the main branch ${MAIN_BRANCH}."
         exit 0
     fi
     if (( ${GIT_HEAD_TIME} - ${NPM_NEXT_TIME} < ${DEPLOY_INTERVAL})); then
       # The last version was published long enough before the current commit
-      echo "Skipping deployment: Latest deployment occurred less than $DEPLOY_INTERVAL seconds ago."
+      echo "Skipping deployment: Latest deployment occurred less than ${DEPLOY_INTERVAL} seconds ago."
       exit 0
     fi
     ;;
 esac
 
-###############################################################################
-# Deployment info                                                             #
-###############################################################################
+################################################################################
+# Deployment info                                                              #
+################################################################################
 
 echo "+------------------------------------------------------------+"
-if [[ ${CI_BUILD_TYPE} == "tag" ]]; then
+if [[ "${CI_BUILD_TYPE}" == "tag" ]]; then
   echo "| Deploying release to npm and documentation to gh-pages     |"
 else
   echo "| Deploying pre-release to npm and documentation to gh-pages |"
@@ -127,12 +155,13 @@ fi
 echo "+------------------------------------------------------------+"
 echo ""
 
-###############################################################################
-# npm deployment                                                              #
-###############################################################################
+################################################################################
+# npm deployment                                                               #
+################################################################################
 
 echo "Deploying to npm..."
-if [[ ${CI_BUILD_TYPE} == "tag" ]]; then
+echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+if [[ "${CI_BUILD_TYPE}" == "tag" ]]; then
   gulp lib:dist:publish
 else
   gulp lib:dist:publish --dev-dist ${BUILD_ID}
@@ -140,9 +169,9 @@ fi
 
 echo "Successfully deployed to npm"
 
-###############################################################################
-# gh-pages deployment                                                         #
-###############################################################################
+################################################################################
+# gh-pages deployment                                                          #
+################################################################################
 
 echo "Deploying to gh-pages..."
 


### PR DESCRIPTION
- Stop confusing PRs to `master` with pushes to `master`
- Ensure consistent quoting of the shell variables