### PR TITLE
Update self-dependency

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -1,10 +1,10 @@
-import * as buildTools from "turbo-gulp"; // Going meta
-// import * as buildTools from "./build/lib/index";
+// import * as buildTools from "turbo-gulp"; // Going meta
+import * as buildTools from "turbo-gulp";
+import { LibTarget, registerLibTasks } from "turbo-gulp/targets/lib";
+import { MochaTarget, registerMochaTasks } from "turbo-gulp/targets/mocha";
 
 import gulp from "gulp";
 import minimist from "minimist";
-
-gulp.registry()
 
 interface Options {
   devDist?: string;
@@ -24,13 +24,13 @@ const project: buildTools.Project = {
   srcDir: "src",
 };
 
-const lib: buildTools.LibTarget = {
+const lib: LibTarget = {
   project,
   name: "lib",
   srcDir: "src/lib",
   scripts: ["**/*.ts"],
   mainModule: "index",
-  outModules: buildTools.OutModules.Both,
+  // outModules: buildTools.OutModules.Both,
   dist: {
     packageJsonMap: (old: buildTools.PackageJson): buildTools.PackageJson => {
       const version: string = options.devDist !== undefined ? `${old.version}-build.${options.devDist}` : old.version;
@@ -62,16 +62,17 @@ const lib: buildTools.LibTarget = {
   },
 };
 
-const test: buildTools.MochaTarget = {
+const test: MochaTarget = {
   project,
   name: "test",
   srcDir: "src",
   scripts: ["test/**/*.ts", "lib/**/*.ts", "e2e/*/*.ts"],
   customTypingsDir: "src/custom-typings",
-  outModules: buildTools.OutModules.Both,
+  // outModules: buildTools.OutModules.Both,
   tscOptions: {
     skipLibCheck: true,
   },
+  // generateTestMain: true,
   copy: [
     {
       src: "e2e",
@@ -85,8 +86,8 @@ const test: buildTools.MochaTarget = {
   },
 };
 
-const libTasks: any = buildTools.registerLibTasks(gulp, lib);
-buildTools.registerMochaTasks(gulp, test);
+const libTasks: any = registerLibTasks(gulp, lib);
+registerMochaTasks(gulp, test);
 buildTools.projectTasks.registerAll(gulp, project);
 
 gulp.task("all:tsconfig.json", gulp.parallel("lib:tsconfig.json", "test:tsconfig.json"));

--- a/src/e2e/node-lib/test-resources/lib._tsconfig.json
+++ b/src/e2e/node-lib/test-resources/lib._tsconfig.json
@@ -41,10 +41,8 @@
     "noImplicitUseStrict": false,
     "noLib": false,
     "noResolve": false,
-    "outDir": "../../build/lib",
     "preserveConstEnums": true,
     "removeComments": false,
-    "rootDir": "",
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
@@ -53,6 +51,8 @@
     "suppressImplicitAnyIndexErrors": false,
     "target": "es2017",
     "traceResolution": false,
+    "rootDir": "",
+    "outDir": "../../build/lib",
     "typeRoots": []
   },
   "include": [

--- a/src/lib/options/tsc.ts
+++ b/src/lib/options/tsc.ts
@@ -1,3 +1,5 @@
+import { deleteUndefinedProperties } from "../utils/utils";
+
 export { CompilerOptions } from "typescript";
 
 // tslint:disable:max-line-length
@@ -172,6 +174,34 @@ export function mergeTscOptions(base: CustomTscOptions, extra?: CustomTscOptions
   return {...base, ...extra};
 }
 
+/**
+ * Returns a shallow copy of `customOptions` where the custom and undefined options are removed.
+ *
+ * @param customOptions Base tsc options to standardize.
+ * @return Standardized options.
+ */
 export function toStandardTscOptions(customOptions: CustomTscOptions): TscOptions {
-  return mergeTscOptions({...customOptions, mjsModule: undefined});
+  const result: TscOptions = mergeTscOptions(customOptions, {mjsModule: undefined});
+  deleteUndefinedProperties(result);
+  return result;
+}
+
+/**
+ * Returns a boolean indicating if `.js` files will be emitted.
+ *
+ * @param customOptions Options to check.
+ * @return Boolean indicating if `.js` files will be emitted.
+ */
+export function hasJsOutput(customOptions: CustomTscOptions): boolean {
+  return customOptions.mjsModule === undefined || customOptions.module !== undefined;
+}
+
+/**
+ * Returns a boolean indicating if `.mjs` files will be emitted.
+ *
+ * @param customOptions Options to check.
+ * @return Boolean indicating if `.mjs` files will be emitted.
+ */
+export function hasMjsOutput(customOptions: CustomTscOptions): boolean {
+  return customOptions.mjsModule !== undefined;
 }

--- a/src/lib/target-tasks/_typescript.ts
+++ b/src/lib/target-tasks/_typescript.ts
@@ -1,7 +1,7 @@
 import { IMinimatch, Minimatch } from "minimatch";
 import { posix as posixPath } from "path";
 import { CustomTscOptions } from "../options/tsc";
-import { AbsPosixPath, RelPosixPath } from "../types";
+import { AbsPosixPath } from "../types";
 import * as matcher from "../utils/matcher";
 
 export interface TypescriptConfig {

--- a/src/lib/target-tasks/build-typescript.ts
+++ b/src/lib/target-tasks/build-typescript.ts
@@ -10,7 +10,6 @@ import { Tagged } from "ts-tagged";
 import { TaskFunction } from "undertaker";
 import vinylFs from "vinyl-fs";
 import { CustomTscOptions, toStandardTscOptions, TscOptions } from "../options/tsc";
-import { deleteUndefinedProperties } from "../utils/utils";
 import { ResolvedTsLocations, resolveTsLocations, TypescriptConfig } from "./_typescript";
 
 type TypescriptErrorHash = Tagged<string, "TypescriptErrorHash">;
@@ -63,7 +62,6 @@ export function getBuildTypescriptTask(
     outDir: resolved.outDir,
     typeRoots: resolved.typeRoots,
   };
-  deleteUndefinedProperties(customTscOptions);
 
   const task: TaskFunction = function () {
     let mjsStream: NodeJS.ReadableStream | undefined;

--- a/src/lib/targets/_base.ts
+++ b/src/lib/targets/_base.ts
@@ -1,4 +1,4 @@
-import { existsSync, FSWatcher } from "fs";
+import { FSWatcher } from "fs";
 import { Minimatch } from "minimatch";
 import { posix as posixPath } from "path";
 import { Readable as ReadableStream } from "stream";

--- a/src/lib/targets/lib.ts
+++ b/src/lib/targets/lib.ts
@@ -289,7 +289,7 @@ function resolveLibTarget(target: LibTarget): ResolvedLibTarget {
   } else {
     const defaultDistDir: AbsPosixPath = path.posix.join(base.project.absDistDir, target.name);
     const defaultPackageJsonMap: (pkg: PackageJson) => PackageJson = pkg => pkg;
-    const defaultCopy: (dest: AbsPosixPath) => CopyOptions[] = (dest: AbsPosixPath) => [{
+    const defaultCopy: (dest: AbsPosixPath) => CopyOptions[] = (_: AbsPosixPath) => [{
       files: ["./*.md"],
     }];
 
@@ -409,24 +409,28 @@ export function generateLibTasks(taker: Undertaker, targetOptions: LibTarget): L
 
       // dist:copy:dist
       if (target.dist.copy !== undefined) {
-        const [copyBaseTask, copyBaseWatchTask]: [Undertaker.TaskFunction, Undertaker.TaskFunction] = getCopy(
+        const [copyBaseTask, _]: [Undertaker.TaskFunction, Undertaker.TaskFunction] = getCopy(
           taker,
           target.project.absRoot,
           target.dist.distDir,
           target.dist.copy,
         );
+        // tslint:disable-next-line:no-unused-expression
+        void _; // TODO: Properly unused var error
         copyTasks.push(nameTask(`${target.name}:dist:copy:dist`, copyBaseTask));
       }
     }
 
     // dist:copy:lib
     if (target.copy !== undefined) {
-      const [copyBaseTask, copyBaseWatchTask]: [Undertaker.TaskFunction, Undertaker.TaskFunction] = getCopy(
+      const [copyBaseTask, _]: [Undertaker.TaskFunction, Undertaker.TaskFunction] = getCopy(
         taker,
         target.srcDir,
         target.dist.distDir,
         target.copy,
       );
+      // tslint:disable-next-line:no-unused-expression
+      void _; // TODO: Properly unused var error
       copyTasks.push(nameTask(`${target.name}:dist:copy:lib`, copyBaseTask));
     }
 

--- a/src/lib/utils/matcher.ts
+++ b/src/lib/utils/matcher.ts
@@ -74,5 +74,5 @@ export function relative(from: PosixPath, matcher: minimatch.IMinimatch): minima
  * @return String corresponding to `matcher`.
  */
 export function asString(matcher: minimatch.IMinimatch): string {
-  return (matcher.negate ? "!" : "") + matcher.pattern;
+  return matcher.negate ? `!${matcher.pattern}` : matcher.pattern;
 }

--- a/src/lib/utils/node-async.ts
+++ b/src/lib/utils/node-async.ts
@@ -57,7 +57,7 @@ export interface ExecFileErrorData {
  * @return Normalized `Buffer` value.
  */
 function asBuffer(val: string | Buffer): Buffer {
-  return val instanceof Buffer ? val : new Buffer(val, "UTF-8");
+  return val instanceof Buffer ? val : Buffer.from(val, "UTF-8");
 }
 
 export class ExecFileError extends Incident<ExecFileErrorData, "ExecFileError", Error> {
@@ -203,7 +203,12 @@ export class SpawnedProcess {
         const [stdout, stderr]: [Buffer, Buffer] = this.getBuffers();
         resolve({stdout, stderr, exit: this.exit});
       } else {
+        this.process.once("error", (err: Error) => {
+          this.process.removeAllListeners();
+          reject(err);
+        });
         this.process.once("exit", (code: number | null, signal: string | null): void => {
+          this.process.removeAllListeners();
           let exit: Exit;
           if (code !== null) {
             exit = {type: "code", code};

--- a/src/lib/utils/project.ts
+++ b/src/lib/utils/project.ts
@@ -53,9 +53,9 @@ export function getVersionMessage(version: string): string {
 export async function commitVersion(version: string, projectRoot?: string): Promise<void> {
   const tag: string = getVersionTag(version);
   const message: string = getVersionMessage(version);
-  await git.execGit("add", ["."]);
-  await git.execGit("commit", ["-m", message]);
-  await git.execGit("tag", ["-a", tag, "-m", message]);
+  await git.execGit("add", ["."], {cwd: projectRoot});
+  await git.execGit("commit", ["-m", message], {cwd: projectRoot});
+  await git.execGit("tag", ["-a", tag, "-m", message], {cwd: projectRoot});
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -136,7 +136,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/fs-extra@^5.0.2", "@types/fs-extra@^5.0.3":
+"@types/fs-extra@^5.0.3":
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-5.0.4.tgz#b971134d162cc0497d221adde3dbb67502225599"
   dependencies:
@@ -224,17 +224,6 @@
 "@types/object-inspect@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@types/object-inspect/-/object-inspect-1.4.0.tgz#649d85af82d9d47f165add37586fd1665bdd5c1a"
-
-"@types/orchestrator@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@types/orchestrator/-/orchestrator-0.3.2.tgz#cd15c6cea978a32b98e5054239cbcc78e55671f1"
-  dependencies:
-    "@types/node" "*"
-    "@types/q" "*"
-
-"@types/q@*":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.0.tgz#87567ea1206935405e51c03635b6cbf3a01f7bc4"
 
 "@types/semver@^5.5.0":
   version "5.5.0"
@@ -501,7 +490,7 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
-async-done@^1.2.0, async-done@^1.2.2, async-done@^1.2.4, async-done@^1.3.1:
+async-done@^1.2.0, async-done@^1.2.2, async-done@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/async-done/-/async-done-1.3.1.tgz#14b7b73667b864c8f02b5b253fc9c6eddb777f3e"
   dependencies:
@@ -540,76 +529,13 @@ aws4@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
 
-babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
+babel-code-frame@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
     chalk "^1.1.3"
     esutils "^2.0.2"
     js-tokens "^3.0.2"
-
-babel-generator@^6.18.0:
-  version "6.26.1"
-  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
-  dependencies:
-    babel-messages "^6.23.0"
-    babel-runtime "^6.26.0"
-    babel-types "^6.26.0"
-    detect-indent "^4.0.0"
-    jsesc "^1.3.0"
-    lodash "^4.17.4"
-    source-map "^0.5.7"
-    trim-right "^1.0.1"
-
-babel-messages@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-runtime@^6.22.0, babel-runtime@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.11.0"
-
-babel-template@^6.16.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
-  dependencies:
-    babel-runtime "^6.26.0"
-    babel-traverse "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    lodash "^4.17.4"
-
-babel-traverse@^6.18.0, babel-traverse@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
-  dependencies:
-    babel-code-frame "^6.26.0"
-    babel-messages "^6.23.0"
-    babel-runtime "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    debug "^2.6.8"
-    globals "^9.18.0"
-    invariant "^2.2.2"
-    lodash "^4.17.4"
-
-babel-types@^6.18.0, babel-types@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
-  dependencies:
-    babel-runtime "^6.26.0"
-    esutils "^2.0.2"
-    lodash "^4.17.4"
-    to-fast-properties "^1.0.3"
-
-babylon@^6.18.0:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
 bach@^1.0.0:
   version "1.2.0"
@@ -679,10 +605,6 @@ braces@^2.3.0, braces@^2.3.1:
     snapdragon-node "^2.0.1"
     split-string "^3.0.2"
     to-regex "^3.0.1"
-
-browser-stdout@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
 
 browser-stdout@1.3.1:
   version "1.3.1"
@@ -920,10 +842,6 @@ combined-stream@1.0.6, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.11.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
-
 commander@2.15.1:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
@@ -971,10 +889,6 @@ copy-props@^2.0.1:
   dependencies:
     each-props "^1.3.0"
     is-plain-object "^2.0.1"
-
-core-js@^2.4.0:
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -1048,7 +962,7 @@ debug@3.1.0, debug@3.X, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8:
+debug@^2.1.2, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -1137,12 +1051,6 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
-detect-indent@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
-  dependencies:
-    repeating "^2.0.0"
-
 detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
@@ -1150,10 +1058,6 @@ detect-libc@^1.0.2:
 detect-newline@2.X:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
-
-diff@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.1.tgz#aa8567a6eed03c531fc89d3f711cd0e5259dec75"
 
 diff@3.5.0, diff@^3.1.0, diff@^3.2.0:
   version "3.5.0"
@@ -1190,12 +1094,6 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
   dependencies:
     once "^1.4.0"
-
-end-of-stream@~0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-0.1.5.tgz#8e177206c3c80837d85632e8b9359dfe8b2f6eaf"
-  dependencies:
-    once "~1.3.0"
 
 error-ex@^1.2.0:
   version "1.3.2"
@@ -1243,10 +1141,6 @@ esm@3.0.56:
   version "3.0.56"
   resolved "https://registry.yarnpkg.com/esm/-/esm-3.0.56.tgz#55630f3111dfb07c59613bbfc5d7920da85f83f1"
 
-esm@^3.0.31:
-  version "3.0.66"
-  resolved "https://registry.yarnpkg.com/esm/-/esm-3.0.66.tgz#be1c12acbab8a14692f715b8bb363fbf438caf09"
-
 esprima@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
@@ -1289,18 +1183,6 @@ execa@^0.10.0:
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
-  dependencies:
-    cross-spawn "^5.0.1"
-    get-stream "^3.0.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
-
-execa@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"
@@ -1499,7 +1381,7 @@ fs-extra@^5.0.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^6.0.0, fs-extra@^6.0.1:
+fs-extra@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
   dependencies:
@@ -1634,10 +1516,6 @@ globals@^11.1.0:
   version "11.7.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.7.0.tgz#a583faa43055b1aca771914bf68258e2fc125673"
 
-globals@^9.18.0:
-  version "9.18.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
-
 globby@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
@@ -1657,10 +1535,6 @@ glogg@^1.0.0:
 graceful-fs@4.X, graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
-
-growl@1.10.3:
-  version "1.10.3"
-  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.3.tgz#1926ba90cf3edfe2adb4927f5880bc22c66c790f"
 
 growl@1.10.5:
   version "1.10.5"
@@ -1689,17 +1563,6 @@ gulp-cli@^2.0.0, gulp-cli@^2.0.1:
     v8flags "^3.0.1"
     yargs "^7.1.0"
 
-gulp-mocha@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/gulp-mocha/-/gulp-mocha-5.0.0.tgz#ed70ebd5fadae6c98d87af13dbbad5a602e217b2"
-  dependencies:
-    dargs "^5.1.0"
-    execa "^0.8.0"
-    mocha "^4.1.0"
-    npm-run-path "^2.0.2"
-    plugin-error "^0.1.2"
-    through2 "^2.0.3"
-
 gulp-mocha@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/gulp-mocha/-/gulp-mocha-6.0.0.tgz#80f32bc705ce30747f355ddb8ccd96a1c73bef13"
@@ -1712,7 +1575,7 @@ gulp-mocha@^6.0.0:
     supports-color "^5.4.0"
     through2 "^2.0.3"
 
-gulp-rename@^1.2.2, gulp-rename@^1.3.0:
+gulp-rename@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/gulp-rename/-/gulp-rename-1.3.0.tgz#2e789d8f563ab0c924eeb62967576f37ff4cb826"
 
@@ -1751,17 +1614,6 @@ gulp-typedoc@^2.2.0:
     event-stream "^3.3.4"
     fancy-log "^1.3.2"
     plugin-error "^0.1.2"
-
-gulp-typescript@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/gulp-typescript/-/gulp-typescript-4.0.2.tgz#80bb9e376e7aa87b763a6ad5fe054a5d078da1e6"
-  dependencies:
-    ansi-colors "^1.0.1"
-    plugin-error "^0.1.2"
-    source-map "^0.6.1"
-    through2 "^2.0.3"
-    vinyl "^2.1.0"
-    vinyl-fs "^3.0.0"
 
 gulp-typescript@^5.0.0-alpha.2:
   version "5.0.0-alpha.3"
@@ -1819,10 +1671,6 @@ has-ansi@^2.0.0:
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
-
-has-flag@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -1931,7 +1779,7 @@ interpret@^1.0.0, interpret@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
-invariant@^2.2.0, invariant@^2.2.2:
+invariant@^2.2.0:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -2021,12 +1869,6 @@ is-extendable@^1.0.1:
 is-extglob@^2.1.0, is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
-
-is-finite@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
-  dependencies:
-    number-is-nan "^1.0.0"
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
@@ -2158,18 +2000,6 @@ istanbul-lib-hook@^1.1.0:
   dependencies:
     append-transform "^0.4.0"
 
-istanbul-lib-instrument@^1.10.0:
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz#724b4b6caceba8692d3f1f9d0727e279c401af7b"
-  dependencies:
-    babel-generator "^6.18.0"
-    babel-template "^6.16.0"
-    babel-traverse "^6.18.0"
-    babel-types "^6.18.0"
-    babylon "^6.18.0"
-    istanbul-lib-coverage "^1.2.0"
-    semver "^5.3.0"
-
 istanbul-lib-instrument@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.1.tgz#406406730a395acb2e50f0d98137ace16bd4a970"
@@ -2191,16 +2021,6 @@ istanbul-lib-report@^1.1.3:
     path-parse "^1.0.5"
     supports-color "^3.1.2"
 
-istanbul-lib-source-maps@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz#20fb54b14e14b3fb6edb6aca3571fd2143db44e6"
-  dependencies:
-    debug "^3.1.0"
-    istanbul-lib-coverage "^1.1.2"
-    mkdirp "^0.5.1"
-    rimraf "^2.6.1"
-    source-map "^0.5.3"
-
 istanbul-lib-source-maps@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz#ffe6be4e7ab86d3603e4290d54990b14506fc9b1"
@@ -2211,7 +2031,7 @@ istanbul-lib-source-maps@^1.2.5:
     rimraf "^2.6.1"
     source-map "^0.5.3"
 
-istanbul-reports@^1.4.0, istanbul-reports@^1.4.1:
+istanbul-reports@^1.4.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.5.0.tgz#c6c2867fa65f59eb7dcedb7f845dfc76aaee70f9"
   dependencies:
@@ -2235,10 +2055,6 @@ js-yaml@^3.7.0:
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
-
-jsesc@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
 
 jsesc@^2.5.1:
   version "2.5.1"
@@ -2376,7 +2192,7 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
-lodash@^4.17.4, lodash@^4.17.5:
+lodash@^4.17.5:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -2559,22 +2375,7 @@ mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mocha@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-4.1.0.tgz#7d86cfbcf35cb829e2754c32e17355ec05338794"
-  dependencies:
-    browser-stdout "1.3.0"
-    commander "2.11.0"
-    debug "3.1.0"
-    diff "3.3.1"
-    escape-string-regexp "1.0.5"
-    glob "7.1.2"
-    growl "1.10.3"
-    he "1.1.1"
-    mkdirp "0.5.1"
-    supports-color "4.4.0"
-
-mocha@^5.1.1, mocha@^5.2.0:
+mocha@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
   dependencies:
@@ -2707,38 +2508,6 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-nyc@^11.7.1:
-  version "11.9.0"
-  resolved "https://registry.yarnpkg.com/nyc/-/nyc-11.9.0.tgz#4106e89e8fbe73623a1fc8b6ecb7abaa271ae1e4"
-  dependencies:
-    archy "^1.0.0"
-    arrify "^1.0.1"
-    caching-transform "^1.0.0"
-    convert-source-map "^1.5.1"
-    debug-log "^1.0.1"
-    default-require-extensions "^1.0.0"
-    find-cache-dir "^0.1.1"
-    find-up "^2.1.0"
-    foreground-child "^1.5.3"
-    glob "^7.0.6"
-    istanbul-lib-coverage "^1.1.2"
-    istanbul-lib-hook "^1.1.0"
-    istanbul-lib-instrument "^1.10.0"
-    istanbul-lib-report "^1.1.3"
-    istanbul-lib-source-maps "^1.2.3"
-    istanbul-reports "^1.4.0"
-    md5-hex "^1.2.0"
-    merge-source-map "^1.1.0"
-    micromatch "^3.1.10"
-    mkdirp "^0.5.0"
-    resolve-from "^2.0.0"
-    rimraf "^2.6.2"
-    signal-exit "^3.0.1"
-    spawn-wrap "^1.4.2"
-    test-exclude "^4.2.0"
-    yargs "11.1.0"
-    yargs-parser "^8.0.0"
-
 nyc@^12.0.2:
   version "12.0.2"
   resolved "https://registry.yarnpkg.com/nyc/-/nyc-12.0.2.tgz#8a4a4ed690966c11ec587ff87eea0c12c974ba99"
@@ -2845,26 +2614,12 @@ once@^1.3.0, once@^1.3.1, once@^1.3.2, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-once@~1.3.0:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/once/-/once-1.3.3.tgz#b2e261557ce4c314ec8304f3fa82663e4297ca20"
-  dependencies:
-    wrappy "1"
-
 optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
   dependencies:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
-
-orchestrator@^0.3.8:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/orchestrator/-/orchestrator-0.3.8.tgz#14e7e9e2764f7315fbac184e506c7aa6df94ad7e"
-  dependencies:
-    end-of-stream "~0.1.5"
-    sequencify "~0.0.7"
-    stream-consume "~0.1.0"
 
 ordered-read-streams@^1.0.0:
   version "1.0.1"
@@ -3166,10 +2921,6 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
-regenerator-runtime@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
@@ -3203,12 +2954,6 @@ repeat-element@^1.1.2:
 repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
-
-repeating@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
-  dependencies:
-    is-finite "^1.0.0"
 
 replace-ext@^1.0.0:
   version "1.0.0"
@@ -3326,10 +3071,6 @@ semver-greatest-satisfied-range@^1.1.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
-sequencify@~0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/sequencify/-/sequencify-0.0.7.tgz#90cff19d02e07027fd767f5ead3e7b95d1e7380c"
-
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -3442,7 +3183,7 @@ source-map@^0.4.4:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
+source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
@@ -3546,10 +3287,6 @@ stream-combiner@~0.0.4:
   dependencies:
     duplexer "~0.1.1"
 
-stream-consume@~0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/stream-consume/-/stream-consume-0.1.1.tgz#d3bdb598c2bd0ae82b8cac7ac50b1107a7996c48"
-
 stream-exhaust@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/stream-exhaust/-/stream-exhaust-1.0.2.tgz#acdac8da59ef2bc1e17a2c0ccf6c320d120e555d"
@@ -3608,12 +3345,6 @@ strip-eof@^1.0.0:
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-
-supports-color@4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
-  dependencies:
-    has-flag "^2.0.0"
 
 supports-color@5.4.0, supports-color@^5.2.0, supports-color@^5.3.0, supports-color@^5.4.0:
   version "5.4.0"
@@ -3701,10 +3432,6 @@ to-absolute-glob@^2.0.0:
   dependencies:
     is-absolute "^1.0.0"
     is-negated-glob "^1.0.0"
-
-to-fast-properties@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
 to-fast-properties@^2.0.0:
   version "2.0.0"
@@ -3798,50 +3525,55 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-turbo-gulp@next:
-  version "0.17.1-build.517"
-  resolved "https://registry.yarnpkg.com/turbo-gulp/-/turbo-gulp-0.17.1-build.517.tgz#b7f5867952dfccbdf692aed59e58a7c993c907a0"
+turbo-gulp@0.17.1-build.529:
+  version "0.17.1-build.529"
+  resolved "https://registry.yarnpkg.com/turbo-gulp/-/turbo-gulp-0.17.1-build.529.tgz#cdb4f03d11aee9f56f3e7b7012d0ac891d682629"
   dependencies:
     "@types/del" "^3.0.1"
     "@types/fancy-log" "^1.3.0"
-    "@types/fs-extra" "^5.0.2"
-    "@types/gulp" "^4.0.5"
+    "@types/fs-extra" "^5.0.3"
     "@types/gulp-rename" "^0.0.33"
     "@types/gulp-sourcemaps" "^0.0.32"
     "@types/merge2" "^1.1.4"
     "@types/minimatch" "^3.0.3"
-    "@types/orchestrator" "^0.3.2"
     "@types/semver" "^5.5.0"
     "@types/tmp" "^0.0.33"
+    "@types/undertaker" "^1.2.0"
+    "@types/undertaker-registry" "^1.0.1"
     "@types/vinyl" "^2.0.2"
-    async-done "^1.2.4"
+    "@types/vinyl-fs" "^2.4.8"
+    async-done "^1.3.1"
     del "^3.0.0"
-    esm "^3.0.31"
+    esm "3.0.56"
     fancy-log "^1.3.2"
-    fs-extra "^6.0.0"
-    gulp-mocha "^5.0.0"
-    gulp-rename "^1.2.2"
+    fs-extra "^6.0.1"
+    glob-watcher "^5.0.1"
+    gulp-mocha "^6.0.0"
+    gulp-rename "^1.3.0"
     gulp-sourcemaps "^2.6.4"
     gulp-tslint "^8.1.3"
     gulp-typedoc "^2.2.0"
-    gulp-typescript "^4.0.2"
+    gulp-typescript "^5.0.0-alpha.2"
     incident "^3.1.1"
     json-loader "^0.5.7"
     merge2 "^1.2.2"
     minimatch "^3.0.4"
-    mocha "^5.1.1"
-    nyc "^11.7.1"
-    orchestrator "^0.3.8"
+    mocha "^5.2.0"
+    nyc "^12.0.2"
     plugin-error "^1.0.1"
     raw-loader "^0.5.1"
     semver "^5.5.0"
     tmp "^0.0.33"
+    ts-tagged "^1.0.0"
     tslint "^5.10.0"
     typedoc "^0.11.1"
     typedoc-plugin-external-module-name "^1.1.1"
-    typescript "^2.8.3"
+    typescript "^2.9.2"
+    undertaker "^1.2.0"
+    undertaker-registry "^1.0.1"
     vinyl "^2.1.0"
     vinyl-buffer "^1.0.1"
+    vinyl-fs "^3.0.3"
     vinyl-source-stream "^2.0.0"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
@@ -3890,7 +3622,7 @@ typescript@2.7.2:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
-typescript@^2.8.3, typescript@^2.9.2:
+typescript@^2.9.2:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
 


### PR DESCRIPTION
This commit updates turbo-gulp itself to compile with the upcoming version using new defaults and `mjsModules`.