### PR TITLE
Add support for TSC options override in dist builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - **[Breaking change]** Replace `OutModules` enum by custom compiler option `mjsModule`.
 - **[Breaking change]** Drop support for Pug, Sass, Angular & Webpack.
 - **[Feature]** Expose custom registries for each target.
+- **[Feature]** Add `dist.tscOptions` for `lib` target to override options for
+  distribution builds.
 - **[Fix]** Disable deprecated TsLint rules from the default config
 - **[Fix]** Remove use of experimental `fs/promises` module.
 - **[Internal]** Fix continuous deployment script (stop confusing PRs to master

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -42,6 +42,7 @@ const lib: LibTarget = {
   },
   customTypingsDir: "src/custom-typings",
   tscOptions: {
+    declaration: true,
     skipLibCheck: true,
   },
   typedoc: {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "minimist": "^1.2.0",
     "pre-commit": "^1.2.2",
     "ts-node": "^7.0.0",
-    "turbo-gulp": "next"
+    "turbo-gulp": "0.17.1-build.529"
   },
   "nyc": {
     "include": [

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -15,7 +15,7 @@ export { projectTasks };
 
 export { CleanOptions } from "./options/clean";
 export { CopyOptions } from "./options/copy";
-export { DEV_TSC_OPTIONS, PROD_TSC_OPTIONS, TscOptions } from "./options/tsc";
+export { DEFAULT_TSC_OPTIONS, TscOptions } from "./options/tsc";
 export {
   DEFAULT_TYPED_TSLINT_CONFIG,
   DEFAULT_TYPED_TSLINT_RULES,

--- a/src/lib/options/tsc.ts
+++ b/src/lib/options/tsc.ts
@@ -150,16 +150,6 @@ export const DEFAULT_TSC_OPTIONS: CustomTscOptions = {
   typeRoots: undefined,
 };
 
-export const PROD_TSC_OPTIONS: CustomTscOptions = {
-  ...DEFAULT_TSC_OPTIONS,
-  declaration: true,
-};
-
-export const DEV_TSC_OPTIONS: CustomTscOptions = {
-  ...DEFAULT_TSC_OPTIONS,
-  declaration: false,
-};
-
 /**
  * Merges two typescript compiler options.
  * The options of `extra` override the options of `base`.

--- a/src/lib/targets/_base.ts
+++ b/src/lib/targets/_base.ts
@@ -7,7 +7,7 @@ import Undertaker from "undertaker";
 import Vinyl from "vinyl";
 import { CleanOptions } from "../options/clean";
 import { CopyOptions } from "../options/copy";
-import { CustomTscOptions, DEV_TSC_OPTIONS, mergeTscOptions, TscOptions } from "../options/tsc";
+import { CustomTscOptions, DEFAULT_TSC_OPTIONS, mergeTscOptions, TscOptions } from "../options/tsc";
 import { Project, ResolvedProject, resolveProject } from "../project";
 import { TypescriptConfig } from "../target-tasks/_typescript";
 import { getBuildTypescriptTask, getBuildTypescriptWatchTask } from "../target-tasks/build-typescript";
@@ -91,7 +91,7 @@ export interface TargetBase {
   /**
    * Overrides for the options of the Typescript compiler.
    */
-  tscOptions?: TscOptions;
+  tscOptions?: CustomTscOptions;
 
   /**
    * Path to the `tsconfig.json` file for this target, relative to `project.rootDir`.
@@ -193,7 +193,7 @@ export function resolveTargetBase(target: TargetBase): ResolvedTargetBase {
   const customTypingsDir: AbsPosixPath | undefined = target.customTypingsDir !== undefined
     ? posixPath.join(project.absRoot, target.customTypingsDir)
     : undefined;
-  const tscOptions: TscOptions = mergeTscOptions(DEV_TSC_OPTIONS, target.tscOptions);
+  const tscOptions: TscOptions = mergeTscOptions(DEFAULT_TSC_OPTIONS, target.tscOptions);
 
   const tsconfigJson: AbsPosixPath = target.tsconfigJson !== undefined
     ? posixPath.join(project.absRoot, target.tsconfigJson)

--- a/yarn.lock
+++ b/yarn.lock
@@ -208,12 +208,12 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
 
 "@types/mocha@^5.2.2":
-  version "5.2.4"
-  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.4.tgz#2f8fbdf95c69ebf82150a7864864010f186745bf"
+  version "5.2.5"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.5.tgz#8a4accfc403c124a0bafe8a9fc61a05ec1032073"
 
 "@types/node@*", "@types/node@^10.3.3":
-  version "10.5.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.2.tgz#f19f05314d5421fe37e74153254201a7bf00a707"
+  version "10.5.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.4.tgz#6eccc158504357d1da91434d75e86acde94bb10b"
 
 "@types/npm@^2.0.29":
   version "2.0.29"
@@ -301,8 +301,8 @@ ansi-colors@^1.0.1:
     ansi-wrap "^0.1.0"
 
 ansi-colors@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-2.0.2.tgz#1a95e0163c461846d44cbdea97bb2ac1aa35f1b2"
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-2.0.5.tgz#5da37825fef3e75f3bda47f760d64bfd10e15e10"
 
 ansi-cyan@^0.1.1:
   version "0.1.1"
@@ -1142,8 +1142,8 @@ esm@3.0.56:
   resolved "https://registry.yarnpkg.com/esm/-/esm-3.0.56.tgz#55630f3111dfb07c59613bbfc5d7920da85f83f1"
 
 esprima@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -1230,8 +1230,8 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     is-extendable "^1.0.1"
 
 extend@^3.0.0, extend@~3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
 extglob@^2.0.4:
   version "2.0.4"
@@ -1431,8 +1431,8 @@ gauge@~2.7.3:
     wide-align "^1.1.0"
 
 get-caller-file@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
 
 get-func-name@^2.0.0:
   version "2.0.0"
@@ -1576,8 +1576,8 @@ gulp-mocha@^6.0.0:
     through2 "^2.0.3"
 
 gulp-rename@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/gulp-rename/-/gulp-rename-1.3.0.tgz#2e789d8f563ab0c924eeb62967576f37ff4cb826"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/gulp-rename/-/gulp-rename-1.4.0.tgz#de1c718e7c4095ae861f7296ef4f3248648240bd"
 
 gulp-sourcemaps@^2.6.4:
   version "2.6.4"
@@ -2001,8 +2001,8 @@ istanbul-lib-hook@^1.1.0:
     append-transform "^0.4.0"
 
 istanbul-lib-instrument@^2.1.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.1.tgz#406406730a395acb2e50f0d98137ace16bd4a970"
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.2.tgz#b287cbae2b5f65f3567b05e2e29b275eaf92d25e"
   dependencies:
     "@babel/generator" "7.0.0-beta.51"
     "@babel/parser" "7.0.0-beta.51"
@@ -2317,15 +2317,15 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-mime-db@~1.33.0:
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
+mime-db@~1.35.0:
+  version "1.35.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.35.0.tgz#0569d657466491283709663ad379a99b90d9ab47"
 
 mime-types@^2.1.12, mime-types@~2.1.17:
-  version "2.1.18"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
+  version "2.1.19"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.19.tgz#71e464537a7ef81c15f2db9d97e913fc0ff606f0"
   dependencies:
-    mime-db "~1.33.0"
+    mime-db "~1.35.0"
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -2483,8 +2483,8 @@ npm-bundled@^1.0.1:
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.3.tgz#7e71703d973af3370a9591bafe3a63aca0be2308"
 
 npm-packlist@^1.1.6:
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.10.tgz#1039db9e985727e464df066f4cf0ab6ef85c398a"
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.11.tgz#84e8c683cbe7867d34b1d357d893ce29e28a02de"
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
@@ -3497,8 +3497,8 @@ tslib@^1.8.0, tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
 tslint@^5.10.0:
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.10.0.tgz#11e26bccb88afa02dd0d9956cae3d4540b5f54c3"
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.11.0.tgz#98f30c02eae3cde7006201e4c33cb08b48581eed"
   dependencies:
     babel-code-frame "^6.22.0"
     builtin-modules "^1.1.1"
@@ -3511,11 +3511,11 @@ tslint@^5.10.0:
     resolve "^1.3.2"
     semver "^5.3.0"
     tslib "^1.8.0"
-    tsutils "^2.12.1"
+    tsutils "^2.27.2"
 
-tsutils@^2.12.1:
-  version "2.27.2"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.27.2.tgz#60ba88a23d6f785ec4b89c6e8179cac9b431f1c7"
+tsutils@^2.27.2:
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
   dependencies:
     tslib "^1.8.1"
 
@@ -3593,8 +3593,8 @@ typedoc-default-themes@^0.5.0:
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz#6dc2433e78ed8bea8e887a3acde2f31785bd6227"
 
 typedoc-plugin-external-module-name@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/typedoc-plugin-external-module-name/-/typedoc-plugin-external-module-name-1.1.1.tgz#0ef2d6a760b42c703519c474258b6f062983aa83"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-external-module-name/-/typedoc-plugin-external-module-name-1.1.3.tgz#ea1c8c7650dae7a105f0d9d55a6aa5cab7816db2"
 
 typedoc@^0.11.1:
   version "0.11.1"
@@ -3701,10 +3701,8 @@ urlgrey@^0.4.4:
   resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
 
 use@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/use/-/use-3.1.0.tgz#14716bf03fdfefd03040aef58d8b4b85f3a7c544"
-  dependencies:
-    kind-of "^6.0.2"
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This commit also fixes the emission of type declarations for dist builds.