### PR TITLE
Release v0.19.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,15 @@ notifications:
   email: false
 
 node_js:
-- 12
+  - 12
 
 before_install:
-- export PATH="$(yarn bin):${PATH}"
+  - export PATH="$(yarn bin):${PATH}"
 
 script:
-- echo "Skipping tests"
-# - npm test
+  - npm test
 
 after_script:
-#- cp coverage/lcov.info coverage.lcov
-#- node node_modules/.bin/codecov
-- ./tools/continuous-deployment.travis.sh
+  - cp coverage/lcov.info coverage.lcov
+  - node node_modules/.bin/codecov
+  - ./tools/continuous-deployment.travis.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
-## Next
+# 0.19.0 (2018-05-01)
 
+- **[Breaking Change]** Require Node 12 to fix coverage issues.
 - **[Fix]** TsLint: Ignore void expressions in arrow functions.
 - **[Fix]** Update dependencies.
 - **[Fix]** Default to CJS for tests, ESM is not ready yet.
 - **[Internal]** Update CI script to better support shallow repositories.
 
-## 0.18.0 (2018-12-02)
+# 0.18.0 (2018-12-02)
 
 - **[Breaking change]** Replace `OutModules` enum by custom compiler option `mjsModule`.
 - **[Breaking change]** Drop support for Pug, Sass, Angular & Webpack.
@@ -22,46 +23,46 @@
 - **[Internal]** Fix deprecated Mocha types.
 - **[Internal]** Fix CI build type detection.
 
-## 0.17.1 (2018-05-03)
+# 0.17.1 (2018-05-03)
 
 - **[Fix]** Update dependencies, remove `std/esm` warning.
 
-## 0.17.0 (2018-04-22)
+# 0.17.0 (2018-04-22)
 
 - **[Breaking change]** Update dependencies. Use `esm` instead of `@std/esm`, update Typescript to `2.8.3`.
 - **[Fix]** Fix Node processes spawn on Windows (Mocha, Nyc)
 
-## 0.16.2 (2018-02-07)
+# 0.16.2 (2018-02-07)
 
 - **[Fix]** Fix Typedoc generation: use `tsconfig.json` generated for the lib.
 - **[Fix]** Write source map for `.mjs` files
 - **[Fix]** Copy sources to `_src` when publishing a lib (#87).
 - **[Internal]** Restore continuous deployment of documentation.
 
-## 0.16.1 (2018-01-20)
+# 0.16.1 (2018-01-20)
 
 - **[Feature]** Support `mocha` tests on `.mjs` files (using `@std/esm`). Enabled by default
   if `outModules` is configured to emit `.mjs`. **You currently need to add
   `"@std/esm": {"esm": "cjs"}` to your `package.json`.**
 
-## 0.16.0 (2018-01-09)
+# 0.16.0 (2018-01-09)
 
 - **[Breaking change]** Enable `allowSyntheticDefaultImports` and `esModuleInterop` by default
 - **[Fix]** Allow deep module imports in default Tslint rules
 - **[Fix]** Drop dependency on deprecated `gulp-util`
 - **[Internal]** Replace most custom typings by types from `@types`
 
-## 0.15.8 (2017-12-05)
+# 0.15.8 (2017-12-05)
 
 - **[Fix]** Exit with non-zero code if command tested with coverage fails
 - **[Fix]** Solve duplicated error message when using the `run` mocha task.
 - **[Fix]** Exit with non-zero code when building scripts fails.
 
-## 0.15.7 (2017-11-29)
+# 0.15.7 (2017-11-29)
 
 - **[Feature]** Add `coverage` task to `mocha` target, use it for the default task
 
-## 0.15.6 (2017-11-29)
+# 0.15.6 (2017-11-29)
 
 - **[Fix]** Fix path to source in source maps.
 - **[Fix]** Disable `number-literal-format` in default Tslint rules. It enforced uppercase for hex.
@@ -69,25 +70,25 @@
 - **[Internal]** Enable integration with Codecov
 - **[Internal]** Enable code coverage
 
-## 0.15.5 (2017-11-10)
+# 0.15.5 (2017-11-10)
 
 - **[Feature]** Enable the following TsLint rules: `no-duplicate-switch-case`, `no-implicit-dependencies`,
   `no-return-await`
 - **[Internal]** Update self-dependency `0.15.4`, this restores the README on _npm_
 - **[Internal]** Add homepage and author fields to package.json
 
-## 0.15.4 (2017-11-10)
+# 0.15.4 (2017-11-10)
 
 - **[Fix]** Add support for custom additional copy for distribution builds. [#49](https://github.com/demurgos/turbo-gulp/issues/49)
 - **[Internal]** Update self-dependency to `turbo-gulp`
 - **[Internal]** Add link to license in `README.md`
 
-## 0.15.3 (2017-11-09)
+# 0.15.3 (2017-11-09)
 
 **Rename to `turbo-gulp`**. This package was previously named `demurgos-web-build-tools`.
 This version is fully compatible: you can just change the name of your dependency.
 
-## 0.15.2 (2017-11-09)
+# 0.15.2 (2017-11-09)
 
 **The package is prepared to be renamed `turbo-gulp`.**
 This is the last version released as `demurgos-web-build-tools`.
@@ -96,31 +97,31 @@ This is the last version released as `demurgos-web-build-tools`.
 - **[Fix]** Disable experimental support for `*.mjs` by default.
 - **[Fix]** Do not emit duplicate TS errors
 
-## 0.15.1 (2017-10-19)
+# 0.15.1 (2017-10-19)
 
 - **[Feature]** Add experimental support for `*.mjs` files
 - **[Fix]** Fix support of releases from Continuous Deployment using Travis.
 
-## 0.15.0 (2017-10-18)
+# 0.15.0 (2017-10-18)
 
 - **[Fix]** Add error handling for git deployment.
 - **[Internal]** Enable continuous deployment of the `master` branch.
 
-## 0.15.0-beta.11 (2017-08-29)
+# 0.15.0-beta.11 (2017-08-29)
 
 - **[Feature]** Add `LibTarget.dist.copySrc` option to disable copy of source files to the dist directory.
   This allows to prevent issues with missing custom typings.
 - **[Fix]** Mark `deploy` property of `LibTarget.typedoc` as optional.
 - **[Internal]** Update self-dependency to `v0.15.0-beta.10`.
 
-## 0.15.0-beta.10 (2017-08-28)
+# 0.15.0-beta.10 (2017-08-28)
 
 - **[Breaking]** Update Tslint rules to use `tslint@5.7.0`.
 - **[Fix]** Set `allowJs` to false in default TSC options.
 - **[Fix]** Do not pipe output of git commands to stdout.
 - **[Internal]** Update self-dependency to `v0.15.0-beta.9`.
 
-## 0.15.0-beta.9 (2017-08-28)
+# 0.15.0-beta.9 (2017-08-28)
 
 - **[Breaking]** Drop old-style `test` target.
 - **[Breaking]** Drop old-style `node` target.
@@ -131,51 +132,51 @@ This is the last version released as `demurgos-web-build-tools`.
 - **[Fix]** Run `clean` before `dist`, if defined.
 - **[Fix]** Run `dist` before `publish`.
 
-## 0.15.0-beta.8 (2017-08-26)
+# 0.15.0-beta.8 (2017-08-26)
 
 - **[Fix]** Remove auth token and registry options for `<lib>:dist:publish`. It is better served
   by configuring the environment appropriately.
 
-## 0.15.0-beta.7 (2017-08-26)
+# 0.15.0-beta.7 (2017-08-26)
 
 - **[Feature]** Add `clean` task to `lib` targets.
 - **[Fix]** Ensure that `gitHead` is defined when publishing a package to npm.
 
-## 0.15.0-beta.6 (2017-08-22)
+# 0.15.0-beta.6 (2017-08-22)
 
 - **[Feature]** Add support for Typedoc deployment to a remote git branch (such as `gh-pages`)
 - **[Feature]** Add support for `copy` tasks in new library target.
 - **[Fix]** Resolve absolute paths when compiling scripts with custom typings.
 
-## 0.15.0-beta.5 (2017-08-14)
+# 0.15.0-beta.5 (2017-08-14)
 
 - **[Fix]** Fix package entry for the main module.
 
-## 0.15.0-beta.4 (2017-08-14)
+# 0.15.0-beta.4 (2017-08-14)
 
 - **[Breaking]** Drop ES5 build exposed to browsers with the `browser` field in `package.json`.
 - **[Feature]** Introduce first new-style target (`LibTarget`). it supports typedoc generation, dev builds and
   simple distribution.
 
-## 0.15.0-beta.3 (2017-08-11)
+# 0.15.0-beta.3 (2017-08-11)
 
 - **[Breaking]** Update default lib target to use target-specific `srcDir`.
 - **[Feature]** Allow to complete `srcDir` in target.
 - **[Feature]** Add experimental library distribution supporting deep requires.
 
-## 0.15.0-beta.2 (2017-08-10)
+# 0.15.0-beta.2 (2017-08-10)
 
 - **[Fix]** Default to CommonJS for project tsconfig.json
 - **[Fix]** Add Typescript configuration for default project.
 - **[Internal]** Update self-dependency to `0.15.0-beta.1`.
 
-## 0.15.0-beta.1 (2017-08-09)
+# 0.15.0-beta.1 (2017-08-09)
 
 - **[Feature]** Support typed TSLint rules.
 - **[Internal]** Update gulpfile.ts to use build tools `0.15.0-beta.0`.
 - **[Fix]** Fix regressions caused by `0.15.0-beta.0` (missing type definition).
 
-## 0.15.0-beta.0 (2017-08-09)
+# 0.15.0-beta.0 (2017-08-09)
 
 - **[Breaking]** Expose option interfaces directly in the main module instead of the `config` namespace.
 - **[Breaking]** Rename `DEFAULT_PROJECT_OPTIONS` to `DEFAULT_PROJECT`.
@@ -183,21 +184,21 @@ This is the last version released as `demurgos-web-build-tools`.
 - **[Internal]** Convert gulpfile to Typescript, use `ts-node` to run it.
 - **[Internal]** Update dependencies
 
-## 0.14.3 (2017-07-16)
+# 0.14.3 (2017-07-16)
 
 - **[Feature]** Add `:lint:fix` project task to fix some lint errors.
 
-## 0.14.2 (2017-07-10)
+# 0.14.2 (2017-07-10)
 
 - **[Internal]** Update dependencies: add `package-lock.json` and update `tslint`.
 
-## 0.14.1 (2017-06-17)
+# 0.14.1 (2017-06-17)
 
 - **[Internal]** Update dependencies.
 - **[Internal]** Drop dependency on _Bluebird_.
 - **[Internal]** Drop dependency on _typings_.
 
-## 0.14.0 (2017-05-10)
+# 0.14.0 (2017-05-10)
 
 - **[Breaking]** Enforce trailing commas by default for multiline objects
 - **[Feature]** Allow bump from either `master` or a branch with the same name as the tag (exampel: `v1.2.3`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-gulp",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Gulp tasks to boost high-quality projects.",
   "author": "Charles Samborski <demurgos@demurgos.net> (https://demurgos.net)",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -140,13 +140,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/del@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/del/-/del-3.0.1.tgz#4712da8c119873cbbf533ad8dbf1baac5940ac5d"
-  integrity sha512-y6qRq6raBuu965clKgx6FHuiPu3oHdtmzMPXi8Uahsjdq1L6DL5fS/aY5/s71YwM7k6K1QIWvem5vNwlnNGIkQ==
-  dependencies:
-    "@types/glob" "*"
-
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -157,7 +150,7 @@
   resolved "https://registry.yarnpkg.com/@types/fancy-log/-/fancy-log-1.3.0.tgz#a61ab476e5e628cd07a846330df53b85e05c8ce0"
   integrity sha512-mQjDxyOM1Cpocd+vm1kZBP7smwKZ4TNokFeds9LV7OZibmPJFEzY3+xZMrKfUdNT71lv8GoCPD6upKwHxubClw==
 
-"@types/fancy-log@^1.3.0", "@types/fancy-log@^1.3.1":
+"@types/fancy-log@^1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/fancy-log/-/fancy-log-1.3.1.tgz#dd94fbc8c2e2ab8ab402ca8d04bb8c34965f0696"
   integrity sha512-31Dt9JaGfHretvwVxCBrCFL5iC9MQ3zOXpu+8C4qzW0cxc5rJJVGxB5c/vZ+wmeTk/JjPz/D0gv8BZ+Ip6iCqQ==
@@ -174,7 +167,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/fs-extra@^5.0.3", "@types/fs-extra@^5.0.4", "@types/fs-extra@^5.0.5":
+"@types/fs-extra@^5.0.5":
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-5.0.5.tgz#080d90a792f3fa2c5559eb44bd8ef840aae9104b"
   integrity sha512-w7iqhDH9mN8eLClQOYTkhdYUOSpp25eXxfc6VbFOGtzxW34JcvctH2bKjj4jD4++z4R5iO5D+pg48W2e03I65A==
@@ -221,13 +214,6 @@
     "@types/vinyl-fs" "*"
     chokidar "^2.1.2"
 
-"@types/handlebars@^4.0.38":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.1.0.tgz#3fcce9bf88f85fe73dc932240ab3fb682c624850"
-  integrity sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==
-  dependencies:
-    handlebars "*"
-
 "@types/highlight.js@^9.12.3":
   version "9.12.3"
   resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.3.tgz#b672cfaac25cbbc634a0fd92c515f66faa18dbca"
@@ -243,7 +229,7 @@
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
   integrity sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==
 
-"@types/istanbul-lib-report@*", "@types/istanbul-lib-report@^1.1.0", "@types/istanbul-lib-report@^1.1.1":
+"@types/istanbul-lib-report@*", "@types/istanbul-lib-report@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz#e5471e7fa33c61358dd38426189c037a58433b8c"
   integrity sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==
@@ -266,15 +252,10 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
-"@types/lodash@^4.14.110", "@types/lodash@^4.14.123":
+"@types/lodash@^4.14.123":
   version "4.14.123"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.123.tgz#39be5d211478c8dd3bdae98ee75bb7efe4abfe4d"
   integrity sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==
-
-"@types/marked@^0.4.0":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-0.4.2.tgz#64a89e53ea37f61cc0f3ee1732c555c2dbf6452f"
-  integrity sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==
 
 "@types/marked@^0.6.0":
   version "0.6.5"
@@ -345,28 +326,18 @@
     "@types/glob" "*"
     "@types/node" "*"
 
-"@types/semver@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
-  integrity sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==
-
 "@types/semver@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.0.0.tgz#86ba89f02a414e39c68d02b351872e4ed31bd773"
   integrity sha512-OO0srjOGH99a4LUN2its3+r6CBYcplhJ466yLqs+zvAWgphCpS8hYZEZ797tRDP/QKcqTdb/YCN6ifASoAWkrQ==
 
-"@types/shelljs@^0.8.0", "@types/shelljs@^0.8.3":
+"@types/shelljs@^0.8.3":
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.5.tgz#1e507b2f6d1f893269bd3e851ec24419ef9beeea"
   integrity sha512-bZgjwIWu9gHCjirKJoOlLzGi5N0QgZ5t7EXEuoqyWCHTuSddURXo3FOBYDyRPNOWzZ6NbkLvZnVkn483Y/tvcQ==
   dependencies:
     "@types/glob" "*"
     "@types/node" "*"
-
-"@types/tmp@^0.0.33":
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.0.33.tgz#1073c4bc824754ae3d10cfab88ab0237ba964e4d"
-  integrity sha1-EHPEvIJHVK49EM+riKsCN7qWTk0=
 
 "@types/tmp@^0.1.0":
   version "0.1.0"
@@ -378,7 +349,7 @@
   resolved "https://registry.yarnpkg.com/@types/undertaker-registry/-/undertaker-registry-1.0.1.tgz#4306d4a03d7acedb974b66530832b90729e1d1da"
   integrity sha512-Z4TYuEKn9+RbNVk1Ll2SS4x1JeLHecolIbM/a8gveaHsW0Hr+RQMraZACwTO2VD7JvepgA6UO1A1VrbktQrIbQ==
 
-"@types/undertaker@*", "@types/undertaker@^1.2.0", "@types/undertaker@^1.2.2":
+"@types/undertaker@*", "@types/undertaker@^1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/undertaker/-/undertaker-1.2.2.tgz#927da24d0d3279830af96386862b035e040ead74"
   integrity sha512-j4iepCSuY2JGW/hShVtUBagic0klYNFIXP7VweavnYnNC2EjiKxJFeaS9uaJmAT0ty9sQSqTS1aagWMZMV0HyA==
@@ -392,7 +363,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/vinyl-fs@*", "@types/vinyl-fs@^2.4.11", "@types/vinyl-fs@^2.4.9":
+"@types/vinyl-fs@*", "@types/vinyl-fs@^2.4.11":
   version "2.4.11"
   resolved "https://registry.yarnpkg.com/@types/vinyl-fs/-/vinyl-fs-2.4.11.tgz#b98119b8bb2494141eaf649b09fbfeb311161206"
   integrity sha512-2OzQSfIr9CqqWMGqmcERE6Hnd2KY3eBVtFaulVo3sJghplUcaeMdL9ZjEiljcQQeHjheWY9RlNmumjIAvsBNaA==
@@ -401,7 +372,7 @@
     "@types/node" "*"
     "@types/vinyl" "*"
 
-"@types/vinyl@*", "@types/vinyl@^2.0.2", "@types/vinyl@^2.0.3":
+"@types/vinyl@*", "@types/vinyl@^2.0.3":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/vinyl/-/vinyl-2.0.3.tgz#80a6ce362ab5b32a0c98e860748a31bce9bff0de"
   integrity sha512-hrT6xg16CWSmndZqOTJ6BGIn2abKyTw0B58bI+7ioUoj3Sma6u8ftZ1DTI2yCaJamOVGLOnQWiPH3a74+EaqTA==
@@ -1269,18 +1240,6 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
-del@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/del/-/del-3.0.0.tgz#53ecf699ffcbcb39637691ab13baf160819766e5"
-  integrity sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=
-  dependencies:
-    globby "^6.1.0"
-    is-path-cwd "^1.0.0"
-    is-path-in-cwd "^1.0.0"
-    p-map "^1.1.1"
-    pify "^3.0.0"
-    rimraf "^2.2.8"
-
 del@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/del/-/del-4.1.1.tgz#9e8f117222ea44a31ff3a156c049b99052a9f0b4"
@@ -1710,7 +1669,7 @@ from@~0:
   resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
   integrity sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=
 
-fs-extra@^7.0.0, fs-extra@^7.0.1:
+fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
@@ -1969,7 +1928,7 @@ gulp-rename@^1.4.0:
   resolved "https://registry.yarnpkg.com/gulp-rename/-/gulp-rename-1.4.0.tgz#de1c718e7c4095ae861f7296ef4f3248648240bd"
   integrity sha512-swzbIGb/arEoFK89tPY58vg3Ok1bw+d35PfUNwWqdo7KM4jkmuGA78JiDNqR+JeZFaeeHnRg9N7aihX3YPmsyg==
 
-gulp-sourcemaps@^2.6.4, gulp-sourcemaps@^2.6.5:
+gulp-sourcemaps@^2.6.5:
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/gulp-sourcemaps/-/gulp-sourcemaps-2.6.5.tgz#a3f002d87346d2c0f3aec36af7eb873f23de8ae6"
   integrity sha512-SYLBRzPTew8T5Suh2U8jCSDKY+4NARua4aqjj8HOysBh2tSgT9u4jc1FYirAdPx1akUxxDeK++fqw6Jg0LkQRg==
@@ -1986,7 +1945,7 @@ gulp-sourcemaps@^2.6.4, gulp-sourcemaps@^2.6.5:
     strip-bom-string "1.X"
     through2 "2.X"
 
-gulp-tslint@^8.1.3, gulp-tslint@^8.1.4:
+gulp-tslint@^8.1.4:
   version "8.1.4"
   resolved "https://registry.yarnpkg.com/gulp-tslint/-/gulp-tslint-8.1.4.tgz#8519ee25ff97aa749e691d4af0fdaccce5f01f7a"
   integrity sha512-wBoZIEMJRz9urHwolsvQpngA9l931p6g/Liwz1b/KrsVP6jEBFZv/o0NS1TFCQZi/l8mXxz8+v3twhf4HOXxPQ==
@@ -1998,7 +1957,7 @@ gulp-tslint@^8.1.3, gulp-tslint@^8.1.4:
     plugin-error "1.0.1"
     through "~2.3.8"
 
-gulp-typedoc@^2.2.1, gulp-typedoc@^2.2.2:
+gulp-typedoc@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/gulp-typedoc/-/gulp-typedoc-2.2.2.tgz#38e3bd7e2feb04a842c038ca6cf0af5d5d0a54e9"
   integrity sha512-Yd/WoB+NHRFgWqFxNEHym2aIykO3koJq7n62indzBnHoHAZNHbKO5eX+ljkX4OVLt5bmYQZ50RqJCZzS40IalA==
@@ -2008,7 +1967,7 @@ gulp-typedoc@^2.2.1, gulp-typedoc@^2.2.2:
     fancy-log "^1.3.2"
     plugin-error "^0.1.2"
 
-gulp-typescript@^5.0.0, gulp-typescript@^5.0.1:
+gulp-typescript@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/gulp-typescript/-/gulp-typescript-5.0.1.tgz#96c6565a6eb31e08c2aae1c857b1a079e6226d94"
   integrity sha512-YuMMlylyJtUSHG1/wuSVTrZp60k1dMEFKYOvDf7OvbAJWrDtxxD4oZon4ancdWwzjj30ztiidhe4VXJniF0pIQ==
@@ -2037,7 +1996,7 @@ gulplog@^1.0.0:
   dependencies:
     glogg "^1.0.0"
 
-handlebars@*, handlebars@^4.0.6, handlebars@^4.1.0:
+handlebars@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
   integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
@@ -2337,22 +2296,10 @@ is-number@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
   integrity sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==
 
-is-path-cwd@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
-  integrity sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=
-
 is-path-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.1.0.tgz#2e0c7e463ff5b7a0eb60852d851a6809347a124c"
   integrity sha512-Sc5j3/YnM8tDeyCsVeKlm/0p95075DyLmDEIkSgQ7mXkrOX+uTCtmQFm0CYzVyJwcCCmO3k8qfJt17SxQwB5Zw==
-
-is-path-in-cwd@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
-  integrity sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==
-  dependencies:
-    is-path-inside "^1.0.0"
 
 is-path-in-cwd@^2.0.0:
   version "2.1.0"
@@ -2360,13 +2307,6 @@ is-path-in-cwd@^2.0.0:
   integrity sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==
   dependencies:
     is-path-inside "^2.1.0"
-
-is-path-inside@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
-  integrity sha1-jvW33lBDej/cprToZe96pVy0gDY=
-  dependencies:
-    path-is-inside "^1.0.1"
 
 is-path-inside@^2.1.0:
   version "2.1.0"
@@ -2467,7 +2407,7 @@ istanbul-lib-coverage@^2.0.5:
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz#675f0ab69503fad4b1d849f736baaca803344f49"
   integrity sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==
 
-istanbul-lib-report@^2.0.2, istanbul-lib-report@^2.0.7:
+istanbul-lib-report@^2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-2.0.7.tgz#370d80d433c4dbc7f58de63618f49599c74bd954"
   integrity sha512-wLH6beJBFbRBLiTlMOBxmb85cnVM1Vyl36N48e4e/aTKSM3WbOx7zbVIH1SQ537fhhsPbX0/C5JB4qsmyRXXyA==
@@ -2675,7 +2615,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.10, lodash@^4.17.11:
+lodash@^4.17.11:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -2755,11 +2695,6 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
-
-marked@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.4.0.tgz#9ad2c2a7a1791f10a852e0112f77b571dce10c66"
-  integrity sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==
 
 marked@^0.6.0:
   version "0.6.2"
@@ -2996,9 +2931,9 @@ node-environment-flags@1.0.5:
     semver "^5.7.0"
 
 node-fetch@^2.2.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.4.1.tgz#b2e38f1117b8acbedbe0524f041fb3177188255d"
-  integrity sha512-P9UbpFK87NyqBZzUuDBDz4f6Yiys8xm8j7ACDbi6usvFm6KItklQUKjeoqTrYS/S1k6I8oaOC2YLLDr/gg26Mw==
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.5.0.tgz#8028c49fc1191bba56a07adc6e2a954644a48501"
+  integrity sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw==
 
 node-pre-gyp@^0.12.0:
   version "0.12.0"
@@ -3236,7 +3171,7 @@ os-shim@^0.1.2:
   resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
   integrity sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=
 
-os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
+os-tmpdir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -3277,11 +3212,6 @@ p-locate@^3.0.0:
   integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
   dependencies:
     p-limit "^2.0.0"
-
-p-map@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
-  integrity sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==
 
 p-map@^2.0.0:
   version "2.1.0"
@@ -3354,7 +3284,7 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-is-inside@^1.0.1, path-is-inside@^1.0.2:
+path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
   integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
@@ -3486,7 +3416,7 @@ process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
   integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
 
-progress@^2.0.0, progress@^2.0.3:
+progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -3709,7 +3639,7 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-rimraf@^2.2.8, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
+rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
@@ -3804,7 +3734,7 @@ shebang-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
-shelljs@^0.8.2, shelljs@^0.8.3:
+shelljs@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
   integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
@@ -4179,13 +4109,6 @@ timers-ext@^0.1.5:
     es5-ext "~0.10.46"
     next-tick "1"
 
-tmp@^0.0.33:
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
-  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
-  dependencies:
-    os-tmpdir "~1.0.2"
-
 tmp@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
@@ -4271,7 +4194,7 @@ tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
-tslint@^5.12.1, tslint@^5.16.0:
+tslint@^5.16.0:
   version "5.16.0"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.16.0.tgz#ae61f9c5a98d295b9a4f4553b1b1e831c1984d67"
   integrity sha512-UxG2yNxJ5pgGwmMzPMYh/CCnCnh0HfPgtlVRDs1ykZklufFBL1ZoTlWFRz2NQjcoEiDoRp+JyT0lhBbbH/obyA==
@@ -4298,51 +4221,50 @@ tsutils@^2.29.0:
     tslib "^1.8.1"
 
 turbo-gulp@next:
-  version "0.18.0-build.647"
-  resolved "https://registry.yarnpkg.com/turbo-gulp/-/turbo-gulp-0.18.0-build.647.tgz#273827a219d953d8a18de759a5eb774f56527dc9"
-  integrity sha512-v9pqGC/uWwUD06L362Rkih0b6zAxuIZUSlQzFpuWGdfZcwuWdWxNPIgF2Xu6UrilUhdJUVB2/OTqKMtESzoEaw==
+  version "0.18.0-build.650"
+  resolved "https://registry.yarnpkg.com/turbo-gulp/-/turbo-gulp-0.18.0-build.650.tgz#473ab895224b16024d77409eb39e280b07b0e5c3"
+  integrity sha512-16HpXaLGnHd+2x1KvI4hDt7M/4v8ric7x964eSpbY+wA1LIiuADtWCcfjzOXHFNOqGQPVjA9gxWBEmeTc/rwYA==
   dependencies:
-    "@types/del" "^3.0.1"
-    "@types/fancy-log" "^1.3.0"
-    "@types/fs-extra" "^5.0.4"
+    "@types/fancy-log" "^1.3.1"
+    "@types/fs-extra" "^5.0.5"
     "@types/gulp-rename" "^0.0.33"
     "@types/gulp-sourcemaps" "^0.0.32"
-    "@types/istanbul-lib-report" "^1.1.0"
+    "@types/istanbul-lib-report" "^1.1.1"
     "@types/merge2" "^1.1.4"
     "@types/minimatch" "^3.0.3"
-    "@types/semver" "^5.5.0"
-    "@types/tmp" "^0.0.33"
-    "@types/undertaker" "^1.2.0"
+    "@types/semver" "^6.0.0"
+    "@types/tmp" "^0.1.0"
+    "@types/undertaker" "^1.2.2"
     "@types/undertaker-registry" "^1.0.1"
-    "@types/vinyl" "^2.0.2"
-    "@types/vinyl-fs" "^2.4.9"
+    "@types/vinyl" "^2.0.3"
+    "@types/vinyl-fs" "^2.4.11"
     async-done "^1.3.1"
     c88 "^0.3.0"
-    del "^3.0.0"
+    del "^4.1.1"
     fancy-log "^1.3.3"
     fs-extra "^7.0.1"
     glob "^7.1.3"
     glob-watcher "^5.0.3"
     gulp-mocha "^6.0.0"
     gulp-rename "^1.4.0"
-    gulp-sourcemaps "^2.6.4"
-    gulp-tslint "^8.1.3"
-    gulp-typedoc "^2.2.1"
-    gulp-typescript "^5.0.0"
+    gulp-sourcemaps "^2.6.5"
+    gulp-tslint "^8.1.4"
+    gulp-typedoc "^2.2.2"
+    gulp-typescript "^5.0.1"
     incident "^3.2.0"
-    istanbul-lib-report "^2.0.2"
+    istanbul-lib-report "^2.0.8"
     merge2 "^1.2.3"
     minimatch "^3.0.4"
     mocha "^6.1.4"
     plugin-error "^1.0.1"
-    semver "^5.6.0"
-    tmp "^0.0.33"
+    semver "^6.0.0"
+    tmp "^0.1.0"
     ts-tagged "^1.0.0"
-    tslint "^5.12.1"
-    typedoc "^0.14.1"
+    tslint "^5.16.0"
+    typedoc "^0.15.0-0"
     typedoc-plugin-external-module-name "^2.0.0"
-    typescript "^3.2.2"
-    undertaker "^1.2.0"
+    typescript "^3.5.0-dev.20190430"
+    undertaker "^1.2.1"
     undertaker-registry "^1.0.1"
     vinyl "^2.2.0"
     vinyl-buffer "^1.0.1"
@@ -4359,11 +4281,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc-default-themes@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz#6dc2433e78ed8bea8e887a3acde2f31785bd6227"
-  integrity sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=
-
 typedoc-default-themes@^0.6.0-0:
   version "0.6.0-0"
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.6.0-0.tgz#a4867eaf91fb7888efd01680f1328b72e8a33640"
@@ -4378,29 +4295,6 @@ typedoc-plugin-external-module-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/typedoc-plugin-external-module-name/-/typedoc-plugin-external-module-name-2.0.0.tgz#c044da973585cd0d5540f94637265592fc0caae7"
   integrity sha512-BJONvKQWolyNqnzjKQIJflsuvyjapsCPR07maHiRvUOXIbhY56SqmYs+VKevq7SIFXsnlfTEE7meP+6Y/Q2Pyw==
-
-typedoc@^0.14.1:
-  version "0.14.2"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.14.2.tgz#769f457f4f9e4bdb8b5f3b177c86b6a31d8c3dc3"
-  integrity sha512-aEbgJXV8/KqaVhcedT7xG6d2r+mOvB5ep3eIz1KuB5sc4fDYXcepEEMdU7XSqLFO5hVPu0nllHi1QxX2h/QlpQ==
-  dependencies:
-    "@types/fs-extra" "^5.0.3"
-    "@types/handlebars" "^4.0.38"
-    "@types/highlight.js" "^9.12.3"
-    "@types/lodash" "^4.14.110"
-    "@types/marked" "^0.4.0"
-    "@types/minimatch" "3.0.3"
-    "@types/shelljs" "^0.8.0"
-    fs-extra "^7.0.0"
-    handlebars "^4.0.6"
-    highlight.js "^9.13.1"
-    lodash "^4.17.10"
-    marked "^0.4.0"
-    minimatch "^3.0.0"
-    progress "^2.0.0"
-    shelljs "^0.8.2"
-    typedoc-default-themes "^0.5.0"
-    typescript "3.2.x"
 
 typedoc@^0.15.0-0:
   version "0.15.0-0"
@@ -4424,25 +4318,15 @@ typedoc@^0.15.0-0:
     typedoc-default-themes "^0.6.0-0"
     typescript "3.3.x"
 
-typescript@3.2.x:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
-  integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
-
 typescript@3.3.x:
   version "3.3.4000"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.4000.tgz#76b0f89cfdbf97827e1112d64f283f1151d6adf0"
   integrity sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==
 
-typescript@^3.2.2:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
-  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
-
 typescript@^3.5.0-dev.20190430:
-  version "3.5.0-dev.20190430"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.0-dev.20190430.tgz#ac052ffbadf7ddd1bd0ce93ffd832bb204877643"
-  integrity sha512-aNINOCV2FBjRpk6y4ewVanXSXMEqTJgbhvnmHcSYLyB6CNe9quCpjaRHvysV3r9Hop+1ikGSzkbINgfzkvEY8Q==
+  version "3.5.0-dev.20190501"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.0-dev.20190501.tgz#c5442f5ca35289e92618f4c5adde9c6f99f84c10"
+  integrity sha512-sZznRRDJvVpVPxncoBgcQ/d943kofh/+zSlhvrNjZVDVKSkCcYDf3hARFsriT8cbj6D+g6cQGYQP8M92ZSjaLg==
 
 uglify-js@^3.1.4:
   version "3.5.9"
@@ -4467,7 +4351,7 @@ undertaker-registry@^1.0.0, undertaker-registry@^1.0.1:
   resolved "https://registry.yarnpkg.com/undertaker-registry/-/undertaker-registry-1.0.1.tgz#5e4bda308e4a8a2ae584f9b9a4359a499825cc50"
   integrity sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=
 
-undertaker@^1.2.0, undertaker@^1.2.1:
+undertaker@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/undertaker/-/undertaker-1.2.1.tgz#701662ff8ce358715324dfd492a4f036055dfe4b"
   integrity sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==


### PR DESCRIPTION
- **[Breaking Change]** Require Node 12 to fix coverage issues.
- **[Fix]** TsLint: Ignore void expressions in arrow functions.
- **[Fix]** Update dependencies.
- **[Fix]** Default to CJS for tests, ESM is not ready yet.
- **[Internal]** Update CI script to better support shallow repositories.