### PR TITLE
Release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.20.0 (2018-05-10)
 
 - **[Breaking change]** Remove `:` prefix from project tasks. For example, `:lint` is now simply `lint`.
 - **[Breaking change]** Rename `:lint:fix` to `format`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **[Breaking change]** Rename `<lib>:dist:publish` to `<lib>:publish`.
 - **[Fix]** Update to `c88@0.3.1` (use `node-inspector-server` instead of `spawn-wrap`).
 - **[Fix]** Ensure all modules are documented.
+- **[Internal]** Rename pre-release flag: from `--dev-dist` to `--next`.
 
 # 0.19.0 (2018-05-01)
 

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -10,9 +10,8 @@ interface Options {
 }
 
 const options: Options & minimist.ParsedArgs = minimist(process.argv.slice(2), {
-  string: ["devDist"],
-  default: {devDist: undefined},
-  alias: {devDist: "dev-dist"},
+  string: ["next"],
+  default: {next: undefined},
 });
 
 const project: Project = {
@@ -31,7 +30,7 @@ const lib: LibTarget = {
   mainModule: "index",
   dist: {
     packageJsonMap: (old: buildTools.PackageJson): buildTools.PackageJson => {
-      const version: string = options.devDist !== undefined ? `${old.version}-build.${options.devDist}` : old.version;
+      const version: string = options.next !== undefined ? `${old.version}-build.${options.next}` : old.version;
       return <any> {...old, version, scripts: undefined, private: false};
     },
     npmPublish: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-gulp",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Gulp tasks to boost high-quality projects.",
   "author": "Charles Samborski <demurgos@demurgos.net> (https://demurgos.net)",
   "license": "MIT",

--- a/tools/continuous-deployment.travis.sh
+++ b/tools/continuous-deployment.travis.sh
@@ -162,7 +162,7 @@ echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 if [[ ${CI_BUILD_TYPE} == "tag" ]]; then
   gulp lib:dist:publish
 else
-  gulp lib:dist:publish --dev-dist ${BUILD_ID}
+  gulp lib:publish --next ${BUILD_ID}
 fi
 
 echo "Successfully deployed to npm"


### PR DESCRIPTION
- **[Breaking change]** Remove `:` prefix from project tasks. For example, `:lint` is now simply `lint`.
- **[Breaking change]** Rename `:lint:fix` to `format`.
- **[Breaking change]** Rename `<lib>:dist:publish` to `<lib>:publish`.
- **[Fix]** Update to `c88@0.3.1` (use `node-inspector-server` instead of `spawn-wrap`).
- **[Fix]** Ensure all modules are documented.
- **[Internal]** Rename pre-release flag: from `--dev-dist` to `--next`.