### PR TITLE
Release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.21.0 (2019-12-10)
 
 - **[Breaking change]** Require Node 13.2.
 - **[Breaking change]** Use file URI to represent paths.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-gulp",
-  "version": "0.20.2",
+  "version": "0.21.0",
   "description": "Gulp tasks to boost high-quality projects.",
   "author": "Charles Samborski <demurgos@demurgos.net> (https://demurgos.net)",
   "license": "MIT",

--- a/tools/continuous-deployment.travis.sh
+++ b/tools/continuous-deployment.travis.sh
@@ -8,9 +8,10 @@
 #
 # ```bash
 # EMAIL="demurgos@demurgos.net"
+# MAIN_REPO="demurgos/my-repo"
 # OUTPUT_KEYFILE="deploy_key"
 # ssh-keygen -t rsa -C "${EMAIL}" -N "" -f "${OUTPUT_KEYFILE}"
-# travis encrypt-file "${OUTPUT_KEYFILE}"
+# travis encrypt-file "${OUTPUT_KEYFILE}" --com --repo "${MAIN_REPO}"
 # rm "${OUTPUT_KEYFILE}"
 # ```
 # Upload the public key to the repository's setting, then remove the public key and commit the encrypted private key.


### PR DESCRIPTION
- **[Breaking change]** Require Node 13.2.
- **[Breaking change]** Use file URI to represent paths.
- **[Internal]** Migrate CI to `travis.com`.
- **[Internal]** Fix continuous deployment script.