### PR TITLE
Add `afterBuild` and `afterDist` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+- **[Feature]** Add `afterBuild` and `afterDist` options.
+
 # 0.21.0 (2019-12-10)
 
 - **[Breaking change]** Require Node 13.2.


### PR DESCRIPTION
This commit adds two hooks to allow to run external tasks after `{target}:build` and `{target}:dist`.