### PR TITLE
Drop support for `customTypingsDir`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
-- **[Fix]** Update dependencies
+- **[Breaking change]** Drop support for `customTypingsDir` dir.
+- **[Fix]** Update dependencies.
 
 # 0.21.1 (2019-12-10)
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ const lib: buildTools.LibTarget = {
   srcDir: "src/lib",
   scripts: ["**/*.ts"],
   mainModule: "index",
-  customTypingsDir: "src/custom-typings",
   tscOptions: {
     skipLibCheck: true,
   },
@@ -97,7 +96,7 @@ Check the documentation for the list of available tasks and configuration.
 
 ## Recommended project layout
 
-Here 
+Here
 
 ```text
 .

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -37,7 +37,6 @@ const lib: LibTarget = {
       tag: options.next !== undefined ? "next" : "latest",
     },
   },
-  customTypingsDir: "src/custom-typings",
   tscOptions: {
     declaration: true,
     skipLibCheck: true,
@@ -65,7 +64,6 @@ const test: MochaTarget = {
   name: "test",
   srcDir: "src",
   scripts: ["test/**/*.ts", "lib/**/*.ts", "e2e/*/*.ts"],
-  customTypingsDir: "src/custom-typings",
   tscOptions: {
     skipLibCheck: true,
   },

--- a/src/e2e/node-lib/test-resources/lib._tsconfig.json
+++ b/src/e2e/node-lib/test-resources/lib._tsconfig.json
@@ -52,8 +52,7 @@
     "target": "es2017",
     "traceResolution": false,
     "rootDir": "",
-    "outDir": "../../build/lib",
-    "typeRoots": []
+    "outDir": "../../build/lib"
   },
   "include": [
     "./**/*.ts"

--- a/src/lib/target-tasks/build-typescript.ts
+++ b/src/lib/target-tasks/build-typescript.ts
@@ -71,7 +71,6 @@ export function getBuildTypescriptTask(
     ...options.tscOptions,
     rootDir: toSysPath(resolved.rootDir.toString()),
     outDir: toSysPath(resolved.outDir.toString()),
-    typeRoots: resolved.typeRoots !== undefined ? resolved.typeRoots.map(x => toSysPath(x.toString())) : undefined,
   };
 
   const task: TaskFunction = function () {

--- a/src/lib/target-tasks/tsconfig-json.ts
+++ b/src/lib/target-tasks/tsconfig-json.ts
@@ -7,26 +7,18 @@
 
 /** (Placeholder comment, see TypeStrong/typedoc#603) */
 
-import { Furi, relative as furiRelative } from "furi";
+import { relative as furiRelative } from "furi";
 import undertaker from "undertaker";
 import { toStandardTscOptions, TscOptions } from "../options/tsc";
-import { RelPosixPath } from "../types";
 import { ResolvedTsLocations, resolveTsLocations, TypescriptConfig } from "../typescript";
 import { writeJsonFile } from "../utils/project";
 
 export function getTsconfigJsonTask(options: TypescriptConfig): undertaker.TaskFunction {
   const resolved: ResolvedTsLocations = resolveTsLocations(options);
-  let typeRoots: RelPosixPath[] = [];
-  if (resolved.typeRoots !== undefined) {
-    typeRoots = resolved.typeRoots.map(
-      (abs: Furi): RelPosixPath => furiRelative(resolved.tsconfigJsonDir, abs),
-    );
-  }
   const tscOptions: TscOptions = {
     ...toStandardTscOptions(options.tscOptions),
     rootDir: furiRelative(resolved.tsconfigJsonDir, resolved.rootDir),
     outDir: furiRelative(resolved.tsconfigJsonDir, resolved.outDir),
-    typeRoots,
   };
   const tsconfigData: any = {
     compilerOptions: tscOptions,

--- a/src/lib/targets/base.ts
+++ b/src/lib/targets/base.ts
@@ -97,12 +97,6 @@ export interface TargetBase {
   afterBuild?: TaskFunction;
 
   /**
-   * Directory containing custom typings, relative to `project.rootDir`.
-   * Custom typings are typings that are not available on `@types`.
-   */
-  customTypingsDir?: RelPosixPath;
-
-  /**
    * Overrides for the options of the Typescript compiler.
    */
   tscOptions?: CustomTscOptions;
@@ -159,8 +153,6 @@ export interface ResolvedTargetBase {
    */
   readonly afterBuild?: Undertaker.TaskFunction;
 
-  readonly customTypingsDir?: Furi;
-
   readonly tscOptions: CustomTscOptions;
 
   readonly tsconfigJson: Furi;
@@ -209,9 +201,6 @@ export function resolveTargetBase(target: TargetBase): ResolvedTargetBase {
     }
   }
 
-  const customTypingsDir: Furi | undefined = target.customTypingsDir !== undefined
-    ? furiJoin(project.absRoot, target.customTypingsDir)
-    : undefined;
   const tscOptions: TscOptions = mergeTscOptions(DEFAULT_TSC_OPTIONS, target.tscOptions);
 
   const tsconfigJson: Furi = target.tsconfigJson !== undefined
@@ -230,7 +219,6 @@ export function resolveTargetBase(target: TargetBase): ResolvedTargetBase {
     buildDir,
     scripts,
     afterBuild: target.afterBuild,
-    customTypingsDir,
     tscOptions,
     tsconfigJson,
     dependencies,
@@ -305,7 +293,6 @@ export function generateBaseTasks(taker: Undertaker, targetOptions: TargetBase):
   const tsOptions: TypescriptConfig = {
     tscOptions: target.tscOptions,
     tsconfigJson: target.tsconfigJson,
-    customTypingsDir: target.customTypingsDir,
     packageJson: target.project.absPackageJson,
     buildDir: target.buildDir,
     srcDir: target.srcDir,
@@ -313,6 +300,8 @@ export function generateBaseTasks(taker: Undertaker, targetOptions: TargetBase):
   };
 
   const watchTasks: Undertaker.TaskFunction[] = [];
+
+  console.log(tsOptions);
 
   // build:scripts
   result.buildScripts = nameTask(`${target.name}:build:scripts`, getBuildTypescriptTask(tsOptions));

--- a/src/lib/targets/node.ts
+++ b/src/lib/targets/node.ts
@@ -72,8 +72,6 @@ interface ResolvedNodeTarget extends ResolvedTargetBase {
 
   readonly scripts: Iterable<MatcherUri>;
 
-  readonly customTypingsDir?: Furi;
-
   readonly tscOptions: TscOptions;
 
   readonly tsconfigJson: Furi;

--- a/src/lib/typescript.ts
+++ b/src/lib/typescript.ts
@@ -6,7 +6,7 @@
 
 /** (Placeholder comment, see TypeStrong/typedoc#603) */
 
-import { Furi, join as furiJoin, parent as furiParent } from "furi";
+import { Furi, parent as furiParent } from "furi";
 import { IMinimatch, Minimatch } from "minimatch";
 import { CustomTscOptions } from "./options/tsc";
 import { MatcherUri } from "./utils/matcher";
@@ -14,7 +14,6 @@ import { MatcherUri } from "./utils/matcher";
 export interface TypescriptConfig {
   readonly tscOptions: CustomTscOptions;
   readonly tsconfigJson: Furi;
-  readonly customTypingsDir?: Furi;
   readonly packageJson: Furi;
   readonly buildDir: Furi;
   readonly srcDir: Furi;
@@ -36,11 +35,6 @@ export interface ResolvedTsLocations {
    * Root directory containing the sources, relative to `tsconfigJsonDir`.
    */
   readonly rootDir: Furi;
-
-  /**
-   * If the typeRoots are not just `@types`, an array of type root directories, relative to `tsconfigJsonDir`.
-   */
-  readonly typeRoots: Furi[] | undefined;
 
   /**
    * Directory containing the build, relative to `tsconfigJsonDir`
@@ -69,11 +63,6 @@ export function resolveTsLocations(options: TypescriptConfig): ResolvedTsLocatio
 
   const rootDir: Furi = options.srcDir;
 
-  let typeRoots: Furi[] | undefined = undefined;
-  if (options.customTypingsDir !== undefined) {
-    const atTypesDir: Furi = furiJoin(furiParent(options.packageJson), "node_modules", "@types");
-    typeRoots = [atTypesDir, options.customTypingsDir];
-  }
   const outDir: Furi = options.buildDir;
   const relInclude: string[] = [];
   const relExclude: string[] = [];
@@ -89,5 +78,5 @@ export function resolveTsLocations(options: TypescriptConfig): ResolvedTsLocatio
     absScripts.push(script);
   }
 
-  return {tsconfigJson, tsconfigJsonDir, rootDir, typeRoots, outDir, relInclude, relExclude, absScripts};
+  return {tsconfigJson, tsconfigJsonDir, rootDir, outDir, relInclude, relExclude, absScripts};
 }


### PR DESCRIPTION
Passing a custom typings dir forced the use of `typeRoots`. Setting this option overrides the default resolution behavior. This default behavior is relatively complex, especially when using Yarn's Plug'n'Play. By dropping support for `customTypingsDir`, we ensure that the default resolution is always applied. The current state of the TypeScript ecosystem makes it also fairly rare to actually need to embed custom typings. A workaround to continue supporting them is to use Yarn's `file:` protocol.