### PR TITLE
Add workaround for yarnpkg/berry#899

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **[Breaking change]** Drop support for `customTypingsDir` dir.
 - **[Fix]** Update dependencies.
+- **[Fix]** Add workaround for yarnpkg/berry#899.
 
 # 0.21.1 (2019-12-10)
 

--- a/src/lib/project-tasks/lint.ts
+++ b/src/lib/project-tasks/lint.ts
@@ -1,11 +1,10 @@
 /**
  * This module defines the `lint` project task.
  *
+ * @packageDocumentation
  * @module project-tasks/lint
  * @internal
  */
-
-/** (Placeholder comment, see TypeStrong/typedoc#603) */
 
 import { existsSync as fileExistsSync, readFileSync } from "fs";
 import { Furi, join as furiJoin } from "furi";

--- a/src/lib/target-tasks/build-typescript.ts
+++ b/src/lib/target-tasks/build-typescript.ts
@@ -1,13 +1,12 @@
 /**
  * This module generates Typescript compilation tasks.
  *
+ * @packageDocumentation
  * @module target-tasks/build-typescript
  * @internal
  */
 
-/** (Placeholder comment, see TypeStrong/typedoc#603) */
-
-import fs from "fs";
+import { FSWatcher } from "fs";
 import { toSysPath } from "furi";
 import globWatcher from "glob-watcher";
 import gulpRename from "gulp-rename";
@@ -123,8 +122,8 @@ export function getBuildTypescriptTask(
   return task;
 }
 
-export function getBuildTypescriptWatchTask(options: TypescriptConfig): () => fs.FSWatcher {
-  return (): fs.FSWatcher => {
+export function getBuildTypescriptWatchTask(options: TypescriptConfig): () => FSWatcher {
+  return (): FSWatcher => {
     const buildTask: TaskFunction = getBuildTypescriptTask(options, false);
     const resolved: ResolvedTsLocations = resolveTsLocations(options);
     return globWatcher(
@@ -134,6 +133,6 @@ export function getBuildTypescriptWatchTask(options: TypescriptConfig): () => fs
   };
 }
 
-export function getBuildTypescriptWatcher(options: TypescriptConfig): fs.FSWatcher {
+export function getBuildTypescriptWatcher(options: TypescriptConfig): FSWatcher {
   return getBuildTypescriptWatchTask(options)();
 }

--- a/src/lib/target-tasks/copy.ts
+++ b/src/lib/target-tasks/copy.ts
@@ -1,11 +1,10 @@
 /**
  * This module generates copy tasks.
  *
+ * @packageDocumentation
  * @module target-tasks/copy
  * @internal
  */
-
-/** (Placeholder comment, see TypeStrong/typedoc#603) */
 
 import { FSWatcher } from "fs";
 import { Furi, toSysPath } from "furi";

--- a/src/lib/targets/node.ts
+++ b/src/lib/targets/node.ts
@@ -17,10 +17,9 @@
  *
  * Run the the Node application (without building it).
  *
+ * @packageDocumentation
  * @module targets/node
  */
-
-/** (Placeholder comment, see TypeStrong/typedoc#603) */
 
 import { spawn } from "child_process";
 import { Furi, join as furiJoin } from "furi";

--- a/src/lib/utils/node-async.ts
+++ b/src/lib/utils/node-async.ts
@@ -8,8 +8,10 @@
 
 import childProcess from "child_process";
 import fs from "fs";
+import { toSysPath } from "furi";
 import { Incident } from "incident";
 import stream from "stream";
+import { URL } from "url";
 
 export interface ExecFileOptions {
   cwd?: string;
@@ -59,6 +61,10 @@ function asBuffer(val: string | Buffer): Buffer {
   return val instanceof Buffer ? val : Buffer.from(val, "utf8");
 }
 
+function asSysPath(pathLike: string | URL): string {
+  return pathLike instanceof URL ? toSysPath(pathLike) : pathLike;
+}
+
 export class ExecFileError extends Incident<ExecFileErrorData, "ExecFileError", Error> {
   constructor(nativeError: Error, stdout: Buffer | string, stderr: Buffer | string) {
     const data: ExecFileErrorData = {
@@ -75,9 +81,9 @@ export class ExecFileError extends Incident<ExecFileErrorData, "ExecFileError", 
   }
 }
 
-export async function readText(file: fs.PathLike): Promise<string> {
+export async function readText(file: string | URL): Promise<string> {
   return new Promise((resolve, reject) => {
-    fs.readFile(file, {encoding: "UTF-8"}, (err: NodeJS.ErrnoException | null, data: string): void => {
+    fs.readFile(asSysPath(file), {encoding: "UTF-8"}, (err: NodeJS.ErrnoException | null, data: string): void => {
       if (err !== null) {
         reject(err);
       } else {
@@ -87,9 +93,9 @@ export async function readText(file: fs.PathLike): Promise<string> {
   });
 }
 
-export async function writeText(file: fs.PathLike, text: string): Promise<void> {
+export async function writeText(file: string | URL, text: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    fs.writeFile(file, text, {encoding: "UTF-8"}, (err: NodeJS.ErrnoException | null): void => {
+    fs.writeFile(asSysPath(file), text, {encoding: "UTF-8"}, (err: NodeJS.ErrnoException | null): void => {
       if (err !== null) {
         reject(err);
       } else {

--- a/src/lib/utils/project.ts
+++ b/src/lib/utils/project.ts
@@ -6,9 +6,9 @@
 
 /** (Placeholder comment, see TypeStrong/typedoc#603) */
 
-import { PathLike } from "fs";
 import { Furi } from "furi";
 import semver from "semver";
+import { URL } from "url";
 import { Project, ResolvedProject } from "../project";
 import * as git from "./git";
 import { readText, writeText } from "./node-async";
@@ -99,7 +99,7 @@ export interface PackageJson {
  * @param filePath Path of the file to read.
  * @return Promise for the content of the file.
  */
-export async function readJsonFile(filePath: PathLike): Promise<any> {
+export async function readJsonFile(filePath: string | URL): Promise<any> {
   return JSON.parse(await readText(filePath));
 }
 
@@ -113,7 +113,7 @@ export async function readJsonFile(filePath: PathLike): Promise<any> {
  * @param data Data to write.
  * @return Promise resolved once the data is written.
  */
-export async function writeJsonFile(filePath: PathLike, data: any): Promise<void> {
+export async function writeJsonFile(filePath: string | URL, data: any): Promise<void> {
   return writeText(filePath, JSON.stringify(data, null, 2) + "\n");
 }
 


### PR DESCRIPTION
The virtual FS used by Yarn does not support URL instances. This commit provides a temporary workaround by normalizing all paths to strings before calling into the fs module.