### PR TITLE
Release v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.22.0 (2020-02-05)
 
 - **[Breaking change]** Drop support for `customTypingsDir` dir.
 - **[Fix]** Update dependencies.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-gulp",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "description": "Gulp tasks to boost high-quality projects.",
   "author": "Charles Samborski <demurgos@demurgos.net> (https://demurgos.net)",
   "license": "MIT",


### PR DESCRIPTION
- **[Breaking change]** Drop support for `customTypingsDir` dir.
- **[Fix]** Update dependencies.
- **[Fix]** Add workaround for yarnpkg/berry#899.